### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/social-announcements.yml
+++ b/.github/workflows/social-announcements.yml
@@ -1,5 +1,8 @@
 name: Social Announcements
 
+permissions:
+  contents: read
+
 on:
   workflow_run:
     workflows: ["Award Community Badges", "Monthly Top Contributor"]

--- a/community/contributors/basanth-pedapati.json
+++ b/community/contributors/basanth-pedapati.json
@@ -1,6 +1,6 @@
 {
   "username": "basanth-pedapati",
-  "totalPoints": 3,
+  "totalPoints": 6,
   "contributions": [
     {
       "type": "pr_opened",
@@ -8,6 +8,14 @@
       "timestamp": "2025-07-25T21:36:14.211Z",
       "evidence": {
         "pr_number": 33
+      }
+    },
+    {
+      "type": "pr_opened",
+      "points": 3,
+      "timestamp": "2025-07-25T21:37:32.469Z",
+      "evidence": {
+        "pr_number": 34
       }
     }
   ],


### PR DESCRIPTION
Potential fix for [https://github.com/func-Kode/site/security/code-scanning/2](https://github.com/func-Kode/site/security/code-scanning/2)

To fix the problem, add a `permissions` key to the workflow file `.github/workflows/social-announcements.yml`. This key should be placed at the top level (before `jobs:`) to apply to all jobs in the workflow, unless a job-specific override is needed. The minimal required permission for this workflow is likely `contents: read`, since the workflow only checks out code and runs scripts, but does not write to the repository or interact with issues or pull requests. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
