### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -61,7 +61,15 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: `Missing required fields: ${missing.join(', ')}` }, { status: 400 });
     }
 
-    if (!String(body.githubUrl).includes('github.com')) {
+    let githubHostValid = false;
+    try {
+      const parsed = new URL(String(body.githubUrl));
+      // Accept only github.com and www.github.com
+      githubHostValid = ['github.com', 'www.github.com'].includes(parsed.host);
+    } catch {
+      githubHostValid = false;
+    }
+    if (!githubHostValid) {
       return NextResponse.json({ error: 'Please provide a valid GitHub URL' }, { status: 400 });
     }
     if (body.liveUrl && !/^https?:\/\//i.test(String(body.liveUrl))) {


### PR DESCRIPTION
Potential fix for [https://github.com/func-Kode/site/security/code-scanning/3](https://github.com/func-Kode/site/security/code-scanning/3)

To fix the problem, we should parse the `githubUrl` using the standard `URL` constructor and check that its host is exactly `github.com` (or optionally, a known set of allowed GitHub hosts such as `www.github.com`). This ensures that only URLs pointing to GitHub are accepted, and prevents bypasses via substring matches in other parts of the URL. The change should be made in the `POST` handler, specifically replacing the substring check on line 64. We will need to handle cases where the URL is invalid and cannot be parsed, returning an appropriate error message. No new dependencies are required, as the standard `URL` class is available in Node.js and modern browsers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
