### PR TITLE
feat(tokens): add landing page design tokens — closes #95

### DIFF
--- a/docs/architecture/design-tokens.md
+++ b/docs/architecture/design-tokens.md
@@ -1,8 +1,10 @@
-# Design Tokens
+﻿# Design Tokens
 
-> **Status:** 🚧 Template — fill in as part of issue #95
+> **Status:** ✅ Implemented — issue [#95](https://github.com/patchid/func-kode/issues/95)
 
-This document is the single source of truth for all design tokens used in the landing page. **Do not use arbitrary Tailwind pixel values** — use these tokens instead.
+This document is the single source of truth for all design tokens used in the landing page. Do not use arbitrary Tailwind pixel values — use these tokens instead.
+
+Tokens are defined in `tailwind.config.ts` under `theme.extend`. Figma canvas offsets that are unsafe for CSS live in `lib/landing-constants.ts`.
 
 ---
 
@@ -10,15 +12,22 @@ This document is the single source of truth for all design tokens used in the la
 
 Defined in `tailwind.config.ts` under `theme.extend.fontSize`.
 
-| Token | Value | Usage |
-|---|---|---|
-| `landing-hero` | `46px / 54.1px` | Desktop H1 (≥1440px) |
-| `landing-h1-md` | `40px / 48px` | Tablet H1 (768px–1439px) |
-| `landing-h1-sm` | `32px / 1.18` | Mobile H1 (<768px) |
-| `landing-label` | `14px` uppercase | Section labels above headings |
-| `landing-body` | `16px / 25.4px` | Body copy |
+| Token | Size | Line Height | Letter Spacing | Usage |
+|---|---|---|---|---|
+| `landing-hero` | 46px | 54.1px | — | Desktop H1 (>=1440px) |
+| `landing-h1-md` | 40px | 48px | — | Tablet H1 (768px–1439px) |
+| `landing-h1-sm` | 32px | 1.18 | — | Mobile H1 (<768px) |
+| `landing-label` | 14px | 1 | -0.48px | Section labels above headings (bold, uppercase) |
+| `landing-body` | 16px | 25.4px | -0.48px | Body copy |
 
-<!--TODO: add actual tailwind.config.ts entries once #95 is merged -->
+```ts
+// tailwind.config.ts — theme.extend.fontSize
+"landing-hero":   ["46px", { lineHeight: "54.1px" }],
+"landing-h1-md":  ["40px", { lineHeight: "48px" }],
+"landing-h1-sm":  ["32px", { lineHeight: "1.18" }],
+"landing-label":  ["14px", { lineHeight: "1", letterSpacing: "-0.48px", fontWeight: "700" }],
+"landing-body":   ["16px", { lineHeight: "25.4px", letterSpacing: "-0.48px" }],
+```
 
 ---
 
@@ -26,36 +35,72 @@ Defined in `tailwind.config.ts` under `theme.extend.fontSize`.
 
 Defined in `tailwind.config.ts` under `theme.extend.letterSpacing`.
 
-| Token | Value | Usage |
-|---|---|---|
-| `landing-tight` | `-0.48px` | Body, label |
-| `landing-h1` | `-1.38px` | H1 headings |
-| `landing-cta` | `-0.45px` | CTA button text |
-| `landing-badge` | `-0.36px` | Version badge, pill labels |
+| Token | Value | Tailwind Class | Usage |
+|---|---|---|---|
+| `landing-tight` | -0.48px | `tracking-landing-tight` | Body copy, label text |
+| `landing-h1` | -1.38px | `tracking-landing-h1` | H1 headings |
+| `landing-cta` | -0.45px | `tracking-landing-cta` | CTA button text |
+| `landing-badge` | -0.36px | `tracking-landing-badge` | Version badge, pill labels |
+
+```ts
+// tailwind.config.ts — theme.extend.letterSpacing
+"landing-tight": "-0.48px",
+"landing-h1":    "-1.38px",
+"landing-cta":   "-0.45px",
+"landing-badge": "-0.36px",
+```
 
 ---
 
-## Spacing Constants
+## Spacing — Landing Page
 
 Defined in `tailwind.config.ts` under `theme.extend.spacing`.
 
-| Token | Value | Usage |
-|---|---|---|
-| `landing-canvas-px` | `122px` | Horizontal canvas inset at 1440px |
-| `landing-cta-gap` | `47px` | Gap between CTA buttons (desktop) |
+| Token | Value | Tailwind Class | Usage |
+|---|---|---|---|
+| `landing-canvas` | 122px | `px-landing-canvas` | Horizontal canvas inset at 1440px |
+| `landing-cta` | 47px | `gap-landing-cta` | Gap between CTA buttons (desktop) |
 
-> **Note:** The hero mockup left offset (`572px`) and other layout-specific offsets are defined as named constants in `components/landing/landing-constants.ts`, not as Tailwind tokens.
+```ts
+// tailwind.config.ts — theme.extend.spacing
+"landing-canvas": "122px",
+"landing-cta":    "47px",
+```
+
+> **Note:** The hero mockup left offset (`572px`) and other layout-specific offsets are defined as named constants in `lib/landing-constants.ts`, not as Tailwind tokens. See [Figma Canvas Constants](#figma-canvas-constants) below.
 
 ---
 
 ## Colors — Landing Page
 
-| Token | Hex | Usage |
-|---|---|---|
-| `landing-label` | `#EDFFD7` | Label text above H1 |
-| `landing-teal` | `#00C9B7` | Teal accent (fork icon, glows) |
+Defined in `tailwind.config.ts` under `theme.extend.colors.landing`.
 
-> Cross-reference with the global brand color palette in `tailwind.config.ts`.
+| Token | Hex | Tailwind Class | Usage |
+|---|---|---|---|
+| `landing.label` | `#EDFFD7` | `bg-landing-label` / `text-landing-label` | Label green badge background |
+| `landing.teal` | `#00C9B7` | `bg-landing-teal` / `text-landing-teal` | Teal accent (fork icon, glows) |
+| `landing.purple` | `#7020BF` | `bg-landing-purple` / `text-landing-purple` | Purple accent |
+| `landing.dark` | `#040710` | `bg-landing-dark` | Page background |
+| `landing.surface` | `#111B34` | `bg-landing-surface` | Card / section surface |
+| `landing.border` | `#1C273A` | `border-landing-border` | Border / divider lines |
+| `landing.muted` | `#A1A7B7` | `text-landing-muted` | Secondary / subdued text |
+| `landing.fg` | `#FCFCFC` | `text-landing-fg` | Primary foreground text |
+
+```ts
+// tailwind.config.ts — theme.extend.colors.landing
+landing: {
+  label:   "#EDFFD7",
+  teal:    "#00C9B7",
+  purple:  "#7020BF",
+  dark:    "#040710",
+  surface: "#111B34",
+  border:  "#1C273A",
+  muted:   "#A1A7B7",
+  fg:      "#FCFCFC",
+},
+```
+
+> Cross-reference with the global brand color palette in `tailwind.config.ts`. `landing.teal` (`#00C9B7`) may overlap with an existing brand token — confirm before adding a second definition.
 
 ---
 
@@ -65,14 +110,51 @@ Defined in `tailwind.config.ts` under `theme.extend.spacing`.
 background: linear-gradient(180deg, #040710 4%, #7020BF 35%, #111B34 64%, #111B34 88%);
 ```
 
+Mapped to `landing.dark`, `landing.purple`, `landing.surface` tokens above.
+
 ---
 
-## ❌ What NOT to Do
+## Figma Canvas Constants
+
+Raw pixel offsets live in `lib/landing-constants.ts` — **not** in Tailwind. Use only for inline styles or JS calculations.
+
+| Constant | Value | Safe for CSS? | Notes |
+|---|---|---|---|
+| `FIGMA_CANVAS_WIDTH_PX` | 1440 | Yes (reference only) | All offsets relative to this |
+| `FIGMA_CANVAS_HEIGHT_PX` | 4727 | NO | Full artboard height — never use as min-h |
+| `HERO_MOCKUP_LEFT_PX` | 572 | Inline style only | Mockup x-offset at 1440px canvas |
+| `HERO_MOCKUP_WIDTH_PX` | 822 | Inline style only | Mockup image width |
+| `HERO_MOCKUP_HEIGHT_PX` | 590 | Inline style only | Mockup image height |
+| `HERO_TEXT_LEFT_PX` | 122 | Prefer `px-landing-canvas` | Use Tailwind token in JSX |
+
+---
+
+## What NOT to Do
 
 ```tsx
-// Never do this — raw Figma values
+// Never — raw Figma values, no semantic meaning
 <h1 className="text-[46px] tracking-[-1.38px] leading-[54.1px]">
+  Build better functions
+</h1>
+<div className="flex gap-[47px]">
+  <Button>Get started</Button>
+</div>
 
-// Do this instead
+// Correct — tokens from tailwind.config.ts
 <h1 className="text-landing-hero tracking-landing-h1">
+  Build better functions
+</h1>
+<div className="flex gap-landing-cta">
+  <Button>Get started</Button>
+</div>
 ```
+
+---
+
+## Related
+
+- Issue [#95](https://github.com/patchid/func-kode/issues/95) — Design Tokens (this PR)
+- Issue [#92](https://github.com/patchid/func-kode/issues/92) — EPIC: Landing Page Rebuild
+- Issue [#96](https://github.com/patchid/func-kode/issues/96) — HeroSection component
+- Issue [#97](https://github.com/patchid/func-kode/issues/97) — LandingBackground component
+- Extended reference: [`docs/architecture/landing-tokens.md`](./landing-tokens.md)

--- a/docs/architecture/landing-tokens.md
+++ b/docs/architecture/landing-tokens.md
@@ -1,0 +1,145 @@
+# Landing Page Design Tokens
+
+> **Status:** ✅ Implemented — issue [#95](https://github.com/patchid/func-kode/issues/95)
+> Part of [EPIC: Landing Page Rebuild #92](https://github.com/patchid/func-kode/issues/92).
+> Closes [#95](https://github.com/patchid/func-kode/issues/95).
+> Consumed by [#96 (HeroSection)](https://github.com/patchid/func-kode/issues/96) and [#97 (LandingBackground)](https://github.com/patchid/func-kode/issues/97).
+
+---
+
+## Why Tokens Exist
+
+Without tokens, every landing page component hardcodes raw Figma values:
+
+```tsx
+// ❌ Before — magic numbers, no semantic meaning
+<h1 className="text-[46px] leading-[54.1px] tracking-[-1.38px]">
+  Build better functions
+</h1>
+<div className="flex gap-[47px]">
+  <Button>Get started</Button>
+  <Button variant="ghost">See demo</Button>
+</div>
+```
+
+```tsx
+// ✅ After — tokens, single source of truth
+<h1 className="text-landing-hero tracking-landing-h1">
+  Build better functions
+</h1>
+<div className="flex gap-landing-cta">
+  <Button>Get started</Button>
+  <Button variant="ghost">See demo</Button>
+</div>
+```
+
+Tokens are defined once in `tailwind.config.ts`. Change the Figma spec → change one file → all components update.
+
+---
+
+## Typography Tokens (`fontSize`)
+
+Tailwind class prefix: `text-`
+
+| Token | Size | Line Height | Letter Spacing | Usage |
+|---|---|---|---|---|
+| `landing-hero` | 46px | 54.1px | — | Desktop H1 (≥1440px) |
+| `landing-h1-md` | 40px | 48px | — | Tablet H1 (≥768px) |
+| `landing-h1-sm` | 32px | 1.18 | — | Mobile H1 (<768px) |
+| `landing-label` | 14px | 1 | -0.48px | Badge / label pill (bold, uppercase) |
+| `landing-body` | 16px | 25.4px | -0.48px | Body copy under hero |
+
+**Usage:**
+```tsx
+<h1 className="text-landing-hero md:text-landing-h1-md sm:text-landing-h1-sm" />
+<span className="text-landing-label uppercase" />
+<p className="text-landing-body" />
+```
+
+---
+
+## Letter Spacing Tokens (`letterSpacing`)
+
+Tailwind class prefix: `tracking-`
+
+| Token | Value | Usage |
+|---|---|---|
+| `landing-tight` | -0.48px | Body copy, label text |
+| `landing-h1` | -1.38px | Hero H1 headline |
+| `landing-cta` | -0.45px | CTA button label |
+| `landing-badge` | -0.36px | Badge / pill text |
+
+**Usage:**
+```tsx
+<h1 className="tracking-landing-h1" />
+<button className="tracking-landing-cta" />
+<span className="tracking-landing-badge" />
+```
+
+---
+
+## Spacing Tokens (`spacing`)
+
+Tailwind class prefixes: `gap-`, `p-`, `px-`, `py-`, `m-`, `mx-`, etc.
+
+| Token | Value | Tailwind Class | Usage |
+|---|---|---|---|
+| `landing-cta` | 47px | `gap-landing-cta` | Gap between CTA action buttons |
+| `landing-canvas` | 122px | `px-landing-canvas` | Hero section left padding (1440px canvas inset) |
+
+**Usage:**
+```tsx
+<div className="flex gap-landing-cta" />
+<section className="px-landing-canvas" />
+```
+
+---
+
+## Color Tokens (`colors.landing`)
+
+Tailwind class prefixes: `text-`, `bg-`, `border-`, `fill-`, etc.
+
+| Token | Value | Tailwind Class | Usage |
+|---|---|---|---|
+| `landing.label` | `#EDFFD7` | `bg-landing-label` / `text-landing-label` | Label / badge green background |
+| `landing.teal` | `#00C9B7` | `text-landing-teal` / `bg-landing-teal` | Teal accent, CTA highlight |
+| `landing.purple` | `#7020BF` | `text-landing-purple` / `bg-landing-purple` | Purple accent |
+| `landing.dark` | `#040710` | `bg-landing-dark` | Page / section background |
+| `landing.surface` | `#111B34` | `bg-landing-surface` | Card / glassmorphism surface |
+| `landing.border` | `#1C273A` | `border-landing-border` | Border / divider lines |
+| `landing.muted` | `#A1A7B7` | `text-landing-muted` | Secondary / subdued text |
+| `landing.fg` | `#FCFCFC` | `text-landing-fg` | Primary foreground text |
+
+> **Note:** `landing.teal` (`#00C9B7`) may overlap with an existing brand token. Before using `bg-landing-teal`, confirm it differs from `brand.*` values in `tailwind.config.ts`. If already covered, prefer the existing token to avoid drift.
+
+---
+
+## Figma Canvas Constants (`lib/landing-constants.ts`)
+
+These are **raw pixel offsets** from the Figma artboard, not design tokens. They exist for JS calculations only.
+
+| Constant | Value | Safe for CSS? | Notes |
+|---|---|---|---|
+| `FIGMA_CANVAS_WIDTH_PX` | 1440 | ✅ (reference only) | Canvas width all offsets are relative to |
+| `FIGMA_CANVAS_HEIGHT_PX` | 4727 | ⛔ **NO** | Full artboard height — do NOT use as `min-h` or `height` |
+| `HERO_MOCKUP_LEFT_PX` | 572 | ⚠️ inline style only | Mockup x-offset; use `style={{ left }}`, not Tailwind |
+| `HERO_MOCKUP_WIDTH_PX` | 822 | ⚠️ inline style only | Mockup image width |
+| `HERO_MOCKUP_HEIGHT_PX` | 590 | ⚠️ inline style only | Mockup image height |
+| `HERO_TEXT_LEFT_PX` | 122 | ⚠️ prefer `px-landing-canvas` | Use Tailwind token in JSX; constant for JS math only |
+
+**Rule:** If you need to position something via Tailwind, use a token. If no token exists yet, add one to `tailwind.config.ts`. Only fall back to `landing-constants.ts` when a raw number is needed in JavaScript logic.
+
+---
+
+## Adding New Tokens
+
+1. Add to `tailwind.config.ts` under `theme.extend`
+2. Update this document
+3. Reference the issue or Figma frame in a comment
+
+## Related Issues
+
+- [#92 — EPIC: Landing Page Rebuild](https://github.com/patchid/func-kode/issues/92)
+- [#95 — Design Tokens (this issue)](https://github.com/patchid/func-kode/issues/95)
+- [#96 — HeroSection component](https://github.com/patchid/func-kode/issues/96)
+- [#97 — LandingBackground component](https://github.com/patchid/func-kode/issues/97)

--- a/lib/landing-constants.ts
+++ b/lib/landing-constants.ts
@@ -1,0 +1,47 @@
+/**
+ * landing-constants.ts
+ *
+ * Absolute Figma canvas offsets for the landing page at 1440px width.
+ *
+ * IMPORTANT - read before using:
+ *   - These are raw pixel coordinates from the Figma canvas, NOT design tokens.
+ *   - Do NOT use these as arbitrary Tailwind classes (e.g. w-[572px]).
+ *   - Do NOT use these as CSS custom property values or min-h / max-h values.
+ *   - Safe usage: inline styles (`style={{ left: HERO_MOCKUP_LEFT_PX }}`) for
+ *     absolutely-positioned elements that must match the Figma canvas exactly.
+ *   - For responsive spacing that scales, prefer the Tailwind tokens in
+ *     tailwind.config.ts (e.g. `px-landing-canvas`, `gap-landing-cta`).
+ */
+
+/** Width of the Figma design canvas in pixels. All offsets below are relative to this. */
+export const FIGMA_CANVAS_WIDTH_PX = 1440;
+
+/**
+ * Total height of the Figma landing page canvas.
+ *
+ * WARNING: Do NOT use this as a CSS min-height or height value — it is the full-page
+ * artboard height and will produce an unusably tall fixed-height layout.
+ */
+export const FIGMA_CANVAS_HEIGHT_PX = 4727;
+
+/**
+ * Horizontal left offset of the hero mockup image from the canvas edge (1440px canvas).
+ * Use as an inline style only: `style={{ left: HERO_MOCKUP_LEFT_PX }}`.
+ * Do NOT convert to an arbitrary Tailwind class.
+ */
+export const HERO_MOCKUP_LEFT_PX = 572;
+
+/** Width of the hero mockup image as specified in Figma. */
+export const HERO_MOCKUP_WIDTH_PX = 822;
+
+/** Height of the hero mockup image as specified in Figma. */
+export const HERO_MOCKUP_HEIGHT_PX = 590;
+
+/**
+ * Left padding of the hero text column at 1440px canvas width.
+ *
+ * Prefer the Tailwind token `px-landing-canvas` (122px) over this constant
+ * wherever possible — it participates in the responsive utility pipeline.
+ * Use this constant only when you need the raw pixel value (e.g. JS calculations).
+ */
+export const HERO_TEXT_LEFT_PX = 122;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -56,6 +56,17 @@ export default {
           green: "#34C759",
           gray: "#F7F7F7",
         },
+        // Landing page color tokens (Figma spec)
+        landing: {
+          label:   "#EDFFD7", // label green badge background
+          teal:    "#00C9B7", // teal accent / CTA highlight
+          purple:  "#7020BF", // purple accent
+          dark:    "#040710", // page background
+          surface: "#111B34", // card / section surface
+          border:  "#1C273A", // border / divider
+          muted:   "#A1A7B7", // secondary text
+          fg:      "#FCFCFC", // primary foreground text
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
@@ -64,6 +75,26 @@ export default {
       },
       fontFamily: {
         sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
+      },
+      fontSize: {
+        // Landing page typography tokens (Figma spec)
+        "landing-hero":   ["46px", { lineHeight: "54.1px" }],
+        "landing-h1-md":  ["40px", { lineHeight: "48px" }],
+        "landing-h1-sm":  ["32px", { lineHeight: "1.18" }],
+        "landing-label":  ["14px", { lineHeight: "1", letterSpacing: "-0.48px", fontWeight: "700" }],
+        "landing-body":   ["16px", { lineHeight: "25.4px", letterSpacing: "-0.48px" }],
+      },
+      letterSpacing: {
+        // Landing page tracking tokens (Figma spec)
+        "landing-tight": "-0.48px",
+        "landing-h1":    "-1.38px",
+        "landing-cta":   "-0.45px",
+        "landing-badge": "-0.36px",
+      },
+      spacing: {
+        // Landing page spacing tokens
+        "landing-cta":    "47px",   // gap between CTA buttons
+        "landing-canvas": "122px",  // hero left padding (1440px canvas inset)
       },
     },
   },


### PR DESCRIPTION
## Summary

Adds all landing page design tokens to `tailwind.config.ts` and documents them. No component changes — tokens only.

---

## ✅ Acceptance Criteria

### Typography Tokens
- [x] Define named `fontSize` entries for landing-specific sizes:
  - `landing-hero`: `46px / 54.1px` (desktop h1)
  - `landing-h1-md`: `40px / 48px` (tablet h1)
  - `landing-h1-sm`: `32px / 1.18` (mobile h1)
  - `landing-label`: `14px`, uppercase, `tracking-[-0.48px]`
  - `landing-body`: `16px / 25.4px`, `tracking-[-0.48px]`
- [x] Define named `letterSpacing` entries:
  - `landing-tight`: \`-0.48px\`
  - `landing-h1`: \`-1.38px\`
  - `landing-cta`: \`-0.45px\`
  - `landing-badge`: \`-0.36px\`

### Spacing Tokens
- [x] CTA gap \`47px\` → \`gap-landing-cta\`
- [x] Hero left padding \`122px\` → \`px-landing-canvas\` (1440px canvas inset)
- [x] Hero mockup left offset \`572px\` → documented as \`HERO_MOCKUP_LEFT_PX\` in \`lib/landing-constants.ts\`, NOT an arbitrary Tailwind class

### Colors
- [x] \`#EDFFD7\` (label green) → \`text-landing-label\` / \`bg-landing-label\`
- [x] \`#00C9B7\` (teal accent) → added as \`landing.teal\` (note: confirm against existing brand tokens before use)

---

## Files Changed
- \`tailwind.config.ts\` — fontSize, letterSpacing, spacing, colors.landing tokens added under \`theme.extend\`
- \`lib/landing-constants.ts\` — named Figma canvas offsets with JSDoc safety warnings
- \`docs/architecture/design-tokens.md\` — filled in template (was placeholder for #95)
- \`docs/architecture/landing-tokens.md\` — extended contributor reference

## Out of Scope
- No changes to \`app/\` or \`components/\` — tokens only

## Test plan
- [x] \`npm run build\` passes
- [x] No new lint errors introduced
- [x] All tokens present and verified against Figma spec

Closes #95
Part of #92