### PR TITLE
feat(landing): add dismissible event announcement popup - closes #103

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { Poppins } from "next/font/google";
 import { LandingBackground } from "@/components/landing/landing-background";
 import { LandingPageContent } from "@/components/landing/landing-page-content";
+import { EventAnnouncementPopup } from "@/components/landing/event-announcement-popup";
 
 /**
  * Poppins scoped to landing page only.
@@ -19,8 +20,9 @@ const poppins = Poppins({
  *
  * Structure:
  *   <div poppins>
- *     <LandingBackground />   ← absolute inset-0, aria-hidden, z-0
- *     <LandingPageContent />  ← relative z-10, Navbar + HeroSection
+ *     <LandingBackground />          ← absolute inset-0, aria-hidden, z-0
+ *     <LandingPageContent />         ← relative z-10, Navbar + HeroSection
+ *     <EventAnnouncementPopup />     ← client component, fixed z-50, dismissible modal
  *   </div>
  *
  * Page height grows with content — no min-h-[4727px] or any fixed height.
@@ -30,6 +32,7 @@ export default function HomePage() {
     <div className={`relative w-full overflow-x-hidden ${poppins.className}`}>
       <LandingBackground />
       <LandingPageContent />
+      <EventAnnouncementPopup />
     </div>
   );
 }

--- a/components/landing/event-announcement-popup.tsx
+++ b/components/landing/event-announcement-popup.tsx
@@ -56,8 +56,8 @@ export interface EventAnnouncementConfig {
 const DEFAULT_CONFIG: EventAnnouncementConfig = {
   enabled: true,
   eventName: "🎉 Server Launch Party",
-  eventDate: "Sunday — time TBD (IST)",
-  eventDateIso: undefined, // TODO: set to "2026-XX-XXT00:00:00+05:30"
+  eventDate: "Saturday, 13 June 2026 — 11:00 AM IST",
+  eventDateIso: "2026-06-13T12:30:00+05:30", // 11am start + 75min max duration
   eventDescription:
     "Join the func-kode Launch Party to kick off the community, meet other developers, explore the server, and hear what's coming next.",
   ctaLabel: "Join the Party 🚀",

--- a/components/landing/event-announcement-popup.tsx
+++ b/components/landing/event-announcement-popup.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { X, PartyPopper } from "lucide-react";
+import * as Dialog from "@radix-ui/react-dialog";
+
+// ── Safe sessionStorage accessors ─────────────────────────────────────────────
+// sessionStorage throws in sandboxed iframes and SSR contexts.
+// Fail open (return false) so the popup shows when storage is inaccessible.
+
+function getSessionDismissed(key: string): boolean {
+  try {
+    return sessionStorage.getItem(key) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function setSessionDismissed(key: string): void {
+  try {
+    sessionStorage.setItem(key, "true");
+  } catch {
+    // Silently ignore — popup will reappear on next load but that is acceptable
+  }
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Config object for EventAnnouncementPopup.
+ * Update these fields per event — the component handles the rest.
+ *
+ * @param enabled        - Set false to hide without removing code. Default: true.
+ * @param eventDateIso   - ISO 8601 date string. Popup auto-disables after this date.
+ *                         Leave undefined to disable auto-expiry.
+ *                         TODO: Set to the actual event end date before going live,
+ *                         then flip enabled: false after the event passes.
+ */
+export interface EventAnnouncementConfig {
+  enabled: boolean;
+  eventName: string;
+  eventDate: string;
+  eventDateIso?: string;
+  eventDescription: string;
+  ctaLabel: string;
+  ctaHref: string;
+  secondaryLabel?: string;
+  delayMs: number;
+}
+
+// ── Default config — Server Launch Party ──────────────────────────────────────
+// TODO: Fill in eventDateIso and confirm ctaHref Discord link before going live.
+// TODO: Set enabled: false after the event passes.
+
+const DEFAULT_CONFIG: EventAnnouncementConfig = {
+  enabled: true,
+  eventName: "🎉 Server Launch Party",
+  eventDate: "Sunday — time TBD (IST)",
+  eventDateIso: undefined, // TODO: set to "2026-XX-XXT00:00:00+05:30"
+  eventDescription:
+    "Join the func-kode Launch Party to kick off the community, meet other developers, explore the server, and hear what's coming next.",
+  ctaLabel: "Join the Party 🚀",
+  ctaHref: "https://discord.gg/nnkA8xJ3JU",
+  secondaryLabel: "Maybe Later",
+  delayMs: 1500,
+};
+
+const SESSION_DISMISS_KEY = "funkode_event_announcement_dismissed";
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface EventAnnouncementPopupProps {
+  config?: Partial<EventAnnouncementConfig>;
+}
+
+export function EventAnnouncementPopup({
+  config: configOverride,
+}: EventAnnouncementPopupProps) {
+  const config: EventAnnouncementConfig = { ...DEFAULT_CONFIG, ...configOverride };
+
+  // Auto-expiry: disable after eventDateIso if provided
+  const isExpired = config.eventDateIso
+    ? Date.now() > new Date(config.eventDateIso).getTime()
+    : false;
+
+  const isActive = config.enabled && !isExpired;
+
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isActive) return;
+    if (getSessionDismissed(SESSION_DISMISS_KEY)) return;
+
+    const timer = setTimeout(() => setOpen(true), config.delayMs);
+    return () => clearTimeout(timer);
+  }, [isActive, config.delayMs]);
+
+  const handleDismiss = useCallback(() => {
+    setOpen(false);
+    setSessionDismissed(SESSION_DISMISS_KEY);
+  }, []);
+
+  if (!isActive) return null;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(next) => { if (!next) handleDismiss(); }}>
+      <Dialog.Portal>
+        {/* Backdrop — Radix handles focus trap, scroll lock, and Escape key */}
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm animate-in fade-in duration-300" />
+
+        {/* Modal panel — Radix handles aria-describedby linkage automatically */}
+        <Dialog.Content
+          className="
+            fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2
+            bg-card rounded-2xl shadow-2xl border border-border/50
+            animate-in zoom-in-95 duration-300 ease-out
+            focus:outline-none
+            p-0
+          "
+        >
+          {/* Header */}
+          <div className="relative bg-gradient-to-br from-primary/10 via-primary/5 to-transparent rounded-t-2xl p-6 pb-4">
+            {/* Close button — 44px touch target per WCAG 2.5.5 */}
+            <Dialog.Close asChild>
+              <button
+                className="
+                  absolute top-2 right-2
+                  flex items-center justify-center
+                  min-w-[44px] min-h-[44px]
+                  rounded-full text-muted-foreground
+                  hover:text-foreground hover:bg-muted/80
+                  transition-colors
+                "
+                aria-label="Close announcement"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </Dialog.Close>
+
+            <div className="flex items-center gap-3">
+              <div className="w-12 h-12 bg-gradient-to-br from-primary to-primary/70 rounded-2xl flex items-center justify-center shadow-lg flex-shrink-0">
+                <PartyPopper className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <Dialog.Title className="text-xl font-bold text-foreground">
+                  {config.eventName}
+                </Dialog.Title>
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  {config.eventDate}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Body */}
+          <div className="p-6 pt-4 space-y-5">
+            <Dialog.Description className="text-sm text-muted-foreground leading-relaxed">
+              {config.eventDescription}
+            </Dialog.Description>
+
+            {/* CTA Buttons */}
+            <div className="flex flex-col sm:flex-row gap-3">
+              {/* Primary — Dialog.Close triggers onOpenChange(false) → handleDismiss */}
+              <Dialog.Close asChild>
+                <Link
+                  href={config.ctaHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="
+                    flex-1 inline-flex items-center justify-center gap-2
+                    px-5 py-2.5
+                    bg-primary text-primary-foreground
+                    font-semibold rounded-xl shadow-md
+                    hover:opacity-90 hover:shadow-lg
+                    transition-all duration-200
+                    text-sm
+                  "
+                >
+                  {config.ctaLabel}
+                </Link>
+              </Dialog.Close>
+              <Dialog.Close asChild>
+                <button
+                  className="
+                    flex-1 px-5 py-2.5
+                    border border-border bg-background
+                    hover:bg-muted
+                    text-foreground font-medium rounded-xl
+                    transition-colors duration-200
+                    text-sm
+                  "
+                >
+                  {config.secondaryLabel ?? "Maybe Later"}
+                </button>
+              </Dialog.Close>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/docs/components/event-announcement-popup.md
+++ b/docs/components/event-announcement-popup.md
@@ -1,0 +1,142 @@
+﻿# EventAnnouncementPopup Component
+
+> **Status:** ✅ Implemented — issue [#103](https://github.com/patchid/func-kode/issues/103)
+
+---
+
+## Overview
+
+`EventAnnouncementPopup` is a dismissible modal that appears on the landing page after a short delay to promote upcoming community events. It is config-driven so future events only need a new config object — no component changes required.
+
+Built on `@radix-ui/react-dialog` for accessible focus trapping, scroll locking, and keyboard (Escape) dismissal.
+
+---
+
+## Usage
+
+```tsx
+// app/page.tsx
+import { EventAnnouncementPopup } from "@/components/landing/event-announcement-popup";
+
+// Default config (Server Launch Party)
+<EventAnnouncementPopup />
+
+// Custom event
+<EventAnnouncementPopup config={{
+  eventName: "🛠️ Hackathon Kickoff",
+  eventDate: "Saturday 15 Feb, 7:00 PM IST",
+  eventDateIso: "2025-02-15T19:00:00+05:30",
+  eventDescription: "Join our first 48-hour hackathon...",
+  ctaHref: "https://discord.gg/nnkA8xJ3JU",
+  ctaLabel: "Join Now 🚀",
+}} />
+```
+
+---
+
+## Config Reference (`EventAnnouncementConfig`)
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `enabled` | `boolean` | Yes | `true` | Set `false` to hide without removing code |
+| `eventName` | `string` | Yes | `"🎉 Server Launch Party"` | Displayed as the modal title |
+| `eventDate` | `string` | Yes | `"Sunday — time TBD (IST)"` | Human-readable date string shown below title |
+| `eventDateIso` | `string \| undefined` | No | `undefined` | ISO 8601 date — popup auto-disables after this datetime |
+| `eventDescription` | `string` | Yes | See default | 1–2 line description shown in body |
+| `ctaLabel` | `string` | Yes | `"Join the Party 🚀"` | Primary CTA button text |
+| `ctaHref` | `string` | Yes | Discord invite | URL for primary CTA |
+| `secondaryLabel` | `string` | No | `"Maybe Later"` | Dismiss button text |
+| `delayMs` | `number` | Yes | `1500` | Milliseconds before popup appears on page load |
+
+---
+
+## Dismissal Behaviour
+
+- Dismissed by: close button (×), `Maybe Later` button, primary CTA click, backdrop click, or Escape key
+- After dismissal: `sessionStorage` key `funkode_event_announcement_dismissed` is set to `"true"`
+- Does not reappear for the duration of the browser session
+- sessionStorage access is wrapped in try/catch — fails open (shows popup) if storage is inaccessible (sandboxed iframes, SSR)
+
+---
+
+## Auto-Expiry
+
+Set `eventDateIso` to automatically disable the popup after the event passes:
+
+```ts
+const MY_EVENT_CONFIG: Partial<EventAnnouncementConfig> = {
+  eventDateIso: "2025-03-02T21:00:00+05:30", // popup disabled after this
+};
+```
+
+If `eventDateIso` is not set, the popup stays active until `enabled` is manually set to `false`.
+
+**TODO before going live:** Fill in `eventDateIso` with the actual event end datetime and set `enabled: false` after the event passes.
+
+---
+
+## Feature Flag
+
+Disable without touching JSX:
+
+```ts
+// In DEFAULT_CONFIG or via prop override
+enabled: false
+```
+
+The component renders `null` immediately — no DOM output, no delay timer.
+
+---
+
+## Accessibility
+
+| Feature | Implementation |
+|---|---|
+| Focus trap | `@radix-ui/react-dialog` — Tab stays within modal while open |
+| Scroll lock | `@radix-ui/react-dialog` — body scroll locked while modal open |
+| Escape key | `@radix-ui/react-dialog` — closes modal |
+| Focus restoration | `@radix-ui/react-dialog` — focus returns to trigger element on close |
+| Close button touch target | `min-w-[44px] min-h-[44px]` — WCAG 2.5.5 compliant |
+| Screen reader label | `Dialog.Title` announces event name; `Dialog.Description` announces body |
+
+---
+
+## Design System
+
+All styles use existing project tokens — no custom colors:
+
+| Element | Classes |
+|---|---|
+| Header gradient | `bg-gradient-to-br from-primary/10 via-primary/5 to-transparent` |
+| Icon background | `bg-gradient-to-br from-primary to-primary/70` |
+| Primary CTA | `bg-primary text-primary-foreground hover:opacity-90` |
+| Secondary CTA | `border border-border bg-background hover:bg-muted` |
+| Overlay | `bg-black/40 backdrop-blur-sm` |
+| Card | `bg-card border border-border/50 rounded-2xl shadow-2xl` |
+
+---
+
+## Responsive Behaviour
+
+| Breakpoint | Behaviour |
+|---|---|
+| `< 640px` | Full-width modal (capped `max-w-md`), CTAs stack vertically |
+| `>= 640px` | CTAs in a row (`sm:flex-row`) |
+| All sizes | Centered via `left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2` |
+
+---
+
+## Reusing for Future Events
+
+1. Update `DEFAULT_CONFIG` in `event-announcement-popup.tsx` with new event details
+2. Set `eventDateIso` to auto-disable after the event
+3. Deploy — no component restructuring needed
+4. After event: set `enabled: false` or wait for `eventDateIso` auto-expiry
+
+---
+
+## Related
+
+- Issue [#103](https://github.com/patchid/func-kode/issues/103) — this PR
+- Supersedes PR [#104](https://github.com/patchid/func-kode/pulls/104)
+- [`components/landing/event-announcement-popup.tsx`](../../components/landing/event-announcement-popup.tsx)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "func-kode",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "version": "0.9.0",
       "dependencies": {
         "@expo/ngrok": "^4.1.0",
         "@radix-ui/react-checkbox": "^1.3.1",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
         "@radix-ui/react-label": "^2.1.6",
         "@radix-ui/react-slot": "^1.2.2",
@@ -2011,6 +2014,114 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,11 @@
 {
   "name": "func-kode",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "version": "0.9.0",
       "dependencies": {
         "@expo/ngrok": "^4.1.0",
         "@radix-ui/react-checkbox": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,9 @@
 {
   "name": "func-kode",
-  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.9.0",
       "dependencies": {
         "@expo/ngrok": "^4.1.0",
         "@radix-ui/react-checkbox": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@expo/ngrok": "^4.1.0",
     "@radix-ui/react-checkbox": "^1.3.1",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.14",
     "@radix-ui/react-label": "^2.1.6",
     "@radix-ui/react-slot": "^1.2.2",


### PR DESCRIPTION
## Summary

Supersedes #104 (original contributor unresponsive to review). All changes requested by @basanth-p have been addressed. Code taken from #104 as base.

---

## Changes from #104

- [x] **Base branch** — targets `fix/ui-tweaks`, not `main`
- [x] **sessionStorage try/catch** — safe `getSessionDismissed()` / `setSessionDismissed()` helpers; fail open so popup shows when storage is inaccessible
- [x] **Event expiry** — `eventDateIso?: string` field added to config; popup auto-disables after date passes. TODO comments left to fill in date and flip `enabled: false` post-event
- [x] **Focus trap** — replaced raw `role="dialog"` div with `@radix-ui/react-dialog`; focus trap, scroll lock, and Escape key handled automatically
- [x] **On-brand colors** — `from-primary/10 via-primary/5 to-transparent` header; `bg-primary` CTA; removed all `from-purple` / `from-pink` / `from-indigo` gradients
- [x] **Touch target** — close button `min-w-[44px] min-h-[44px]` — WCAG 2.5.5 compliant
- [x] **Button interaction** — `hover:opacity-90 hover:shadow-lg`; removed `hover:scale-[1.02] active:scale-[0.98]`

---

## Acceptance Criteria

- [x] Appears on landing page load after 1.5s delay
- [x] Displays event name, date, description, and CTA
- [x] Dismissible — does not reappear in same session (sessionStorage with try/catch)
- [x] Primary CTA links to Discord
- [x] Fully responsive on mobile (375px+) and desktop
- [x] Config-driven via `EventAnnouncementConfig` — future events just need a new config object
- [x] Feature flag (`enabled: false`) hides popup without code removal
- [x] Auto-expiry via `eventDateIso` field

## Files Changed
- `components/landing/event-announcement-popup.tsx` — new component
- `app/page.tsx` — popup integrated into landing page
- `package.json` / `package-lock.json` — added `@radix-ui/react-dialog`
- `docs/components/event-announcement-popup.md` — new component documentation

## References
- Supersedes: #104
- Closes: #103