### PR TITLE
fix(landing): responsive HeroEditorMockup layout below 1440px — closes #135

### DIFF
--- a/components/landing/hero-section.tsx
+++ b/components/landing/hero-section.tsx
@@ -6,11 +6,10 @@ import { HERO_MOCKUP_LEFT_PX } from "@/lib/landing-constants";
  * HeroSection
  *
  * Layout strategy:
- *   < 1024px  (mobile/tablet):  single column, centred
- *   >= 1024px (lg):             two-column flex row — copy left, mockup right
- *   >= 1440px (Figma canvas):   absolute positioning inside max-w-[1440px] container
- *                                 copy  left = 122px via left-landing-canvas (Tailwind spacing token)
- *                                 mockup left = HERO_MOCKUP_LEFT_PX (572px, lib/landing-constants.ts)
+ *   < 1440px  (mobile / tablet / small desktop): single column, centred — copy then mockup
+ *   >= 1440px (Figma canvas):                 absolute positioning inside max-w-[1440px]
+ *                                               copy  left = 122px (left-landing-canvas)
+ *                                               mockup left = HERO_MOCKUP_LEFT_PX (572px)
  *
  * Typography: all sizes, tracking, leading use design tokens from #95.
  * Layout px values (h-[50px], max-w-[459px] etc.) are Figma frame dimensions,
@@ -23,18 +22,16 @@ import { HERO_MOCKUP_LEFT_PX } from "@/lib/landing-constants";
  */
 export function HeroSection() {
   return (
-    <section className="w-full pb-16 lg:pb-24 lg:pt-[180px]">
+    <section className="w-full pb-16 min-[1440px]:pb-24 min-[1440px]:pt-[180px]">
       {/*
         Outer wrapper:
-          Default → flex-col, centred, 20px side padding
-          lg      → flex-row, px-landing-canvas (122px) padding
+          Default → flex-col, centred, mockup below copy (mobile through tablet / iPad)
           1440px  → absolute-positioned children; container is the 1440px anchor
       */}
       <div
         className="
           relative flex flex-col items-center gap-10 px-5 pt-10
           sm:px-8
-          lg:flex-row lg:items-start lg:justify-between lg:px-landing-canvas lg:gap-0
           min-[1440px]:min-h-[590px] min-[1440px]:items-stretch min-[1440px]:px-0 min-[1440px]:pt-0
         "
       >
@@ -42,7 +39,6 @@ export function HeroSection() {
         <div
           className="
             relative z-10 w-full text-center
-            lg:shrink-0 lg:text-left
             min-[1440px]:absolute min-[1440px]:top-0 min-[1440px]:mx-0 min-[1440px]:text-left
             min-[1440px]:left-landing-canvas
           "
@@ -67,7 +63,7 @@ export function HeroSection() {
             H1 responsive font-size via tokens:
               mobile  → text-landing-h1-sm (32px / 1.18)
               sm      → text-landing-h1-md (40px / 48px)
-              lg      → text-landing-hero  (46px / 54.1px) — matches two-column breakpoint
+              lg      → text-landing-hero  (46px / 54.1px) — at 1440px Figma canvas only
             tracking-landing-h1 (-1.38px) applied at all sizes.
             max-w-[396px]: Figma copy frame inner text-wrap width — layout constraint.
           */}
@@ -76,7 +72,7 @@ export function HeroSection() {
               mx-auto mb-3.5 max-w-[396px] font-bold text-white tracking-landing-h1
               text-landing-h1-sm
               sm:text-landing-h1-md
-              lg:text-landing-hero lg:mx-0
+              min-[1440px]:text-landing-hero min-[1440px]:mx-0
             "
           >
             Build together.
@@ -90,7 +86,7 @@ export function HeroSection() {
             text-landing-body: 16px / 25.4px / tracking-[-0.48px] from #95 token.
             max-w-[456px]: Figma body-text frame width — layout constraint.
           */}
-          <p className="mx-auto mb-[11px] max-w-[456px] text-landing-body text-white/90 lg:mx-0">
+          <p className="mx-auto mb-[11px] max-w-[456px] text-landing-body text-white/90 min-[1440px]:mx-0">
             func(kode) is an open-source developer platform for the Patch ID community.
             Sign up with GitHub, join collaborative builds, and contribute to projects that matter.
           </p>
@@ -103,8 +99,7 @@ export function HeroSection() {
             className="
               mt-[11px] flex flex-col items-center gap-4
               sm:flex-row sm:flex-wrap sm:justify-center
-              lg:justify-start
-              min-[1440px]:gap-landing-cta
+              min-[1440px]:justify-start min-[1440px]:gap-landing-cta
             "
           >
             {/* Primary CTA — white pill */}
@@ -137,25 +132,24 @@ export function HeroSection() {
 
         {/* ── Editor mockup ───────────────────────────────────────────────── */}
         {/*
-          Inline style left: HERO_MOCKUP_LEFT_PX sources the 572px value from
-          lib/landing-constants.ts — satisfies issue #95 / #97 requirement that
-          572px must be a named constant, NOT an arbitrary Tailwind class.
-
-          Safety: `left` only takes visual effect on positioned elements.
-          Below min-[1440px], this element is position:static (in flex flow),
-          so the inline left value is ignored by the browser.
-          At min-[1440px]:absolute, left: 572px activates correctly.
+          Below 1440px: normal flex child — no absolute offset (fixes #135).
+          At min-[1440px]: absolute + left from HERO_MOCKUP_LEFT_PX via CSS variable
+          so the 572px constant is never applied as a bare inline `left` on relative
+          positioning (which pushed the mockup off-screen between lg and 1440px).
 
           max-w-[822px]: Figma mockup frame width — layout constraint.
         */}
         <div
           className="
-            relative z-0 w-full max-w-[822px]
-            lg:flex-1
+            z-0 mx-auto w-full max-w-[822px]
             min-[1440px]:absolute min-[1440px]:top-0 min-[1440px]:mx-0
-            min-[1440px]:w-[822px]
+            min-[1440px]:w-[822px] min-[1440px]:[left:var(--hero-mockup-left)]
           "
-          style={{ left: HERO_MOCKUP_LEFT_PX }}
+          style={
+            {
+              ["--hero-mockup-left" as string]: `${HERO_MOCKUP_LEFT_PX}px`,
+            } as React.CSSProperties
+          }
         >
           <HeroEditorMockup />
         </div>

--- a/docs/components/hero-section.md
+++ b/docs/components/hero-section.md
@@ -57,17 +57,13 @@ All typography values come from design tokens defined in [`architecture/design-t
 ## Layout
 
 ```
-Mobile (< 1024px)
+Mobile through tablet / iPad (< 1440px)
   flex-col, centred
   [Label]
   [H1]
   [Body]
   [CTAs stacked → row at sm]
-  [HeroEditorMockup below]
-
-Desktop (>= 1024px / lg)
-  flex-row, px-landing-canvas (122px) each side
-  [Copy block left]   [HeroEditorMockup right, flex-1]
+  [HeroEditorMockup below, centred]
 
 1440px (Figma pixel-perfect)
   absolute positioning within max-w-[1440px] container
@@ -75,7 +71,9 @@ Desktop (>= 1024px / lg)
   Mockup: left = 572px  (HERO_MOCKUP_LEFT_PX — see lib/landing-constants.ts)
 ```
 
-The `572px` mockup offset is the only value not covered by a Tailwind token. It is documented in `lib/landing-constants.ts` as `HERO_MOCKUP_LEFT_PX` and used at `min-[1440px]:` only. Per issue #97 spec, pixel-perfect Figma positioning is acceptable at 1440px.
+There is **no** side-by-side flex row between 1024px and 1439px — that intermediate layout clipped the mockup on iPad and narrow desktop windows ([#135](https://github.com/patchid/func-kode/issues/135)).
+
+The `572px` mockup offset is the only value not covered by a Tailwind token. It is documented in `lib/landing-constants.ts` as `HERO_MOCKUP_LEFT_PX` and applied at `min-[1440px]:` only via `--hero-mockup-left` (not a always-on inline `left`, which clipped the mockup on viewports below 1440px — see [#135](https://github.com/patchid/func-kode/issues/135)). Per issue #97 spec, pixel-perfect Figma positioning is acceptable at 1440px.
 
 ---
 

--- a/lib/landing-constants.ts
+++ b/lib/landing-constants.ts
@@ -7,8 +7,9 @@
  *   - These are raw pixel coordinates from the Figma canvas, NOT design tokens.
  *   - Do NOT use these as arbitrary Tailwind classes (e.g. w-[572px]).
  *   - Do NOT use these as CSS custom property values or min-h / max-h values.
- *   - Safe usage: inline styles (`style={{ left: HERO_MOCKUP_LEFT_PX }}`) for
- *     absolutely-positioned elements that must match the Figma canvas exactly.
+ *   - Safe usage: CSS custom property + `min-[1440px]:[left:var(--hero-mockup-left)]`
+ *     so the offset applies only when the element is absolutely positioned at 1440px+.
+ *     Do NOT set a bare inline `left` on a relatively positioned flex child (#135).
  *   - For responsive spacing that scales, prefer the Tailwind tokens in
  *     tailwind.config.ts (e.g. `px-landing-canvas`, `gap-landing-cta`).
  */


### PR DESCRIPTION
## Summary

Fixes [#135](https://github.com/patchid/func-kode/issues/135) — the hero editor mockup was missing or clipped on viewports below the 1440px Figma canvas.

- **Root cause 1:** `HERO_MOCKUP_LEFT_PX` (572px) was applied as an always-on inline `left` on a `relative` flex child, shifting the mockup off-screen between `lg` and 1440px.
- **Root cause 2:** A side-by-side `lg:flex-row` layout at 1024px tried to fit copy + an 822px-wide mockup on tablet/narrow desktop, clipping the preview (e.g. iPad Pro 1024px).

**Changes:**
- Apply the 572px offset only at `min-[1440px]:` via `--hero-mockup-left` CSS variable (keeps the named constant from `lib/landing-constants.ts`).
- Keep a **single-column, centered** layout (copy → mockup below) for all widths **below 1440px** — same as mobile/tablet.
- Reserve pixel-perfect absolute positioning for **1440px+** only.
- Update `hero-section.md` and `landing-constants.ts` usage notes.

## Test plan

- [x] `/` at **375px** — centered copy, mockup visible below CTAs
- [x] `/` at **1024px** (iPad Pro) — stacked + centered; mockup fully visible, not clipped
- [x] `/` at **1280px** — same stacked layout (no side-by-side row)
- [x] `/` at **1440px+** — Figma layout: copy left (122px), mockup right (572px offset)
- [x] Resize browser across breakpoints — no mockup disappearing during client navigation
- [x] `npm run build` passes