### PR TITLE
fix: dashboard & inner app pages UI cleanup (closes #118)

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -57,7 +57,7 @@ function LoginContent() {
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-background to-muted/20">
         <div className="flex flex-col items-center gap-4">
           <Image 
-            src="/raccoon.png" 
+            src="/landing/logo.png"
             alt="func(Kode) Raccoon" 
             width={48} 
             height={48} 
@@ -74,7 +74,7 @@ function LoginContent() {
       <div className="w-full max-w-md space-y-8">
         <div className="text-center">
           <Image 
-            src="/raccoon.png" 
+            src="/landing/logo.png"
             alt="func(Kode) Raccoon" 
             width={80} 
             height={80} 
@@ -118,7 +118,7 @@ export default function LoginPage() {
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-background to-muted/20">
         <div className="flex flex-col items-center gap-4">
           <Image 
-            src="/raccoon.png" 
+            src="/landing/logo.png"
             alt="func(Kode) Raccoon" 
             width={48} 
             height={48} 

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -6,7 +6,7 @@ export default function Page() {
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10 bg-brand-gray">
       <div className="w-full max-w-sm mx-auto flex flex-col items-center gap-6">
         <span className="inline-block animate-bounce">
-          <Image src="/raccoon.png" alt="Raccoon Mascot" width={48} height={48} />
+          <Image src="/landing/logo.png" alt="func(Kode) Logo" width={48} height={48} />
         </span>
         <h1 className="text-2xl font-bold text-brand-blue text-center">Sign in with GitHub</h1>
         <p className="text-sm text-muted-foreground text-center -mt-2">No passwords. Just your GitHub account.</p>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -34,13 +34,10 @@ export default function BlogDetailPage() {
   useEffect(() => {
     const supabase = createClient();
     const fetchData = async () => {
-      // Fetch blog
       const { data: blogData } = await supabase.from("blogs").select("*").eq("slug", slug).single();
       setBlog(blogData);
-      // Fetch user
       const { data: userData } = await supabase.auth.getUser();
       setUser(userData.user);
-      // Fetch likes
       if (blogData) {
         const { count: likesCount } = await supabase
           .from("blog_likes")
@@ -55,7 +52,6 @@ export default function BlogDetailPage() {
             .eq("user_id", userData.user.id);
           setLiked(!!userLike);
         }
-        // Fetch comments
         const { data: commentsData } = await supabase
           .from("blog_comments")
           .select("user_email, text, created_at")
@@ -107,10 +103,10 @@ export default function BlogDetailPage() {
       <Link href="/blog" className="text-brand-green hover:underline text-sm">← Back to Blog</Link>
       <div className="flex flex-col items-center gap-4 mb-8 mt-2">
         <span className="inline-block animate-bounce">
-          <Image src={blog.image || "/raccoon.png"} alt="Raccoon Mascot" width={48} height={48} />
+          <Image src={blog.image || "/landing/logo.png"} alt="Blog image" width={48} height={48} />
         </span>
-        <h1 className="text-3xl font-bold text-brand-blue dark:text-brand-blue text-center">{blog.title}</h1>
-        <p className="text-xs text-gray-500">By {blog.author} • {blog.date}</p>
+        <h1 className="text-3xl font-bold text-brand-blue dark:text-white text-center">{blog.title}</h1>
+        <p className="text-sm text-muted-foreground">By {blog.author} • {blog.date}</p>
       </div>
       <article className="prose prose-brand dark:prose-invert max-w-none mb-8">
         {blog.content.split("\n").map((line, i) => (
@@ -127,16 +123,16 @@ export default function BlogDetailPage() {
         >
           👍 {likes}
         </Button>
-        {!user && <span className="text-xs text-gray-500">Sign in to like</span>}
+        {!user && <span className="text-sm text-muted-foreground">Sign in to like</span>}
       </div>
       {/* Comments */}
       <div className="mb-8">
         <h2 className="text-lg font-semibold mb-2">Comments</h2>
         <div className="flex flex-col gap-3">
-          {comments.length === 0 && <span className="text-gray-500 text-sm">No comments yet.</span>}
+          {comments.length === 0 && <span className="text-muted-foreground text-sm">No comments yet.</span>}
           {comments.map((c, i) => (
             <div key={i} className="bg-brand-gray dark:bg-card rounded p-2 text-sm">
-              <span className="font-semibold text-brand-blue dark:text-brand-blue">{c.user_email}</span>: {c.text}
+              <span className="font-semibold text-brand-blue dark:text-gray-300">{c.user_email}</span>: {c.text}
             </div>
           ))}
           <div ref={commentsEndRef} />
@@ -144,7 +140,7 @@ export default function BlogDetailPage() {
         {user ? (
           <form className="flex gap-2 mt-4" onSubmit={handleComment}>
             <input
-              className="flex-1 rounded border px-2 py-1 text-sm bg-white dark:bg-card text-brand-blue dark:text-brand-blue"
+              className="flex-1 rounded border px-2 py-1 text-sm bg-white dark:bg-card text-brand-blue dark:text-foreground"
               placeholder="Add a comment..."
               value={comment}
               onChange={(e) => setComment(e.target.value)}
@@ -152,7 +148,7 @@ export default function BlogDetailPage() {
             <Button type="submit" size="sm">Comment</Button>
           </form>
         ) : (
-          <div className="text-xs text-gray-500 mt-2">Sign in to comment</div>
+          <div className="text-sm text-muted-foreground mt-2">Sign in to comment</div>
         )}
       </div>
     </main>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -35,27 +35,27 @@ export default function BlogListPage() {
     <main className="max-w-2xl mx-auto px-4 py-8">
       <div className="flex flex-col items-center gap-4 mb-8">
         <span className="inline-block animate-bounce">
-          <Image src="/raccoon.png" alt="Raccoon Mascot" width={48} height={48} />
+          <Image src="/landing/logo.png" alt="Raccoon Mascot" width={48} height={48} />
         </span>
-        <h1 className="text-3xl font-bold text-brand-blue dark:text-brand-blue text-center">func(Kode) Blog</h1>
+        <h1 className="text-3xl font-bold text-brand-blue dark:text-white text-center">func(Kode) Blog</h1>
         <p className="text-brand-green text-center">Tips, stories, and guides for coders and creators.</p>
       </div>
       <div className="flex flex-col gap-8">
         {loading ? (
-          <div className="text-center text-gray-500">Loading blogs...</div>
+          <div className="text-center text-muted-foreground">Loading blogs...</div>
         ) : blogs.length === 0 ? (
-          <div className="text-center text-gray-500">No blogs found.</div>
+          <div className="text-center text-muted-foreground">No blogs found.</div>
         ) : (
           blogs.map((blog) => (
-            <div key={blog.slug} className="bg-white dark:bg-card rounded-lg shadow p-5 flex flex-col gap-2">
+            <div key={blog.slug} className="bg-white dark:bg-card rounded-lg shadow border border-border p-6 flex flex-col gap-2">
               <div className="flex items-center gap-3">
-                <Image src={blog.image || "/raccoon.png"} alt={blog.title} width={40} height={40} className="rounded-full" />
+                <Image src={blog.image || "/landing/logo.png"} alt={blog.title} width={40} height={40} className="rounded-full" />
                 <div>
-                  <h2 className="text-xl font-semibold text-brand-blue dark:text-brand-blue">{blog.title}</h2>
-                  <p className="text-xs text-gray-500">By {blog.author} • {blog.date}</p>
+                  <h2 className="text-xl font-semibold text-brand-blue dark:text-white">{blog.title}</h2>
+                  <p className="text-sm text-muted-foreground">By {blog.author} • {blog.date}</p>
                 </div>
               </div>
-              <p className="text-gray-700 dark:text-gray-200 mt-2">{blog.excerpt}</p>
+              <p className="text-foreground mt-2">{blog.excerpt}</p>
               <Link href={`/blog/${blog.slug}`} className="text-brand-green hover:underline text-sm font-semibold mt-2 self-end">Read more →</Link>
             </div>
           ))

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,10 +1,10 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import posthog from "posthog-js";
+import { ANALYTICS_EVENTS, track } from "@/lib/analytics";
 
 interface UserProfile {
   id: string;
@@ -19,19 +19,19 @@ export default function DashboardPage() {
   const router = useRouter();
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
+  const dashboardViewedTracked = useRef(false);
 
   useEffect(() => {
     const supabase = createClient();
-    
+
     const getUser = async () => {
       const { data: { user } } = await supabase.auth.getUser();
-      
+
       if (!user) {
         router.push("/auth/login");
         return;
       }
 
-      // Get user profile
       const { data: profile } = await supabase
         .from('users')
         .select('*')
@@ -40,7 +40,13 @@ export default function DashboardPage() {
 
       if (profile) {
         setProfile(profile);
-        posthog.capture('dashboard_viewed', { username: profile.github_username, onboarded: profile.is_onboarded });
+        if (!dashboardViewedTracked.current) {
+          dashboardViewedTracked.current = true;
+          track(ANALYTICS_EVENTS.DASHBOARD_VIEWED, {
+            username: profile.github_username,
+            onboarded: profile.is_onboarded,
+          });
+        }
       }
 
       setLoading(false);
@@ -53,11 +59,11 @@ export default function DashboardPage() {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="flex flex-col items-center gap-4">
-          <Image 
-            src="/raccoon.png" 
-            alt="func(Kode) Raccoon" 
-            width={48} 
-            height={48} 
+          <Image
+            src="/landing/logo.png"
+            alt="func(Kode) Logo"
+            width={48}
+            height={48}
             className="animate-bounce"
           />
           <p className="text-muted-foreground">Loading your dashboard...</p>
@@ -67,19 +73,19 @@ export default function DashboardPage() {
   }
 
   return (
-    <main className="max-w-4xl mx-auto px-4 py-8">
+    <main className="max-w-4xl mx-auto px-4 py-12">
       {/* Welcome Header */}
       <div className="text-center mb-8">
         <div className="flex items-center justify-center gap-4 mb-4">
-          <Image 
-            src={profile?.avatar_url || "/raccoon.png"} 
-            alt="Profile" 
-            width={80} 
-            height={80} 
+          <Image
+            src={profile?.avatar_url || "/landing/logo.png"}
+            alt="Profile"
+            width={80}
+            height={80}
             className="rounded-full border-4 border-brand-blue shadow-lg"
           />
           <div>
-            <h1 className="text-3xl font-bold text-brand-blue">
+            <h1 className="text-3xl font-bold text-brand-blue dark:text-white">
               Welcome, {profile?.display_name || "Developer"}!
             </h1>
             {profile?.github_username && (
@@ -94,10 +100,10 @@ export default function DashboardPage() {
 
       {/* Quick Actions */}
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-        <Link 
-          href="/projects" 
-          className="bg-card p-6 rounded-2xl shadow-lg hover:shadow-xl transition-all hover:scale-105 border"
-          onClick={() => posthog.capture('dashboard_action_clicked', { action: 'view_projects' })}
+        <Link
+          href="/projects"
+          className="bg-card p-6 rounded-2xl shadow-lg hover:shadow-xl transition-all hover:scale-105 border border-border"
+          onClick={() => track(ANALYTICS_EVENTS.DASHBOARD_ACTION_CLICKED, { action: "view_projects" })}
         >
           <div className="flex items-center gap-4">
             <div className="w-12 h-12 bg-brand-blue rounded-lg flex items-center justify-center">
@@ -110,10 +116,10 @@ export default function DashboardPage() {
           </div>
         </Link>
 
-        <Link 
-          href="/onboard" 
-          className="bg-card p-6 rounded-2xl shadow-lg hover:shadow-xl transition-all hover:scale-105 border"
-          onClick={() => posthog.capture('dashboard_action_clicked', { action: 'complete_profile' })}
+        <Link
+          href="/onboard"
+          className="bg-card p-6 rounded-2xl shadow-lg hover:shadow-xl transition-all hover:scale-105 border border-border"
+          onClick={() => track(ANALYTICS_EVENTS.DASHBOARD_ACTION_CLICKED, { action: "complete_profile" })}
         >
           <div className="flex items-center gap-4">
             <div className="w-12 h-12 bg-brand-green rounded-lg flex items-center justify-center">
@@ -126,10 +132,10 @@ export default function DashboardPage() {
           </div>
         </Link>
 
-        <Link 
-          href="/events" 
-          className="bg-card p-6 rounded-2xl shadow-lg hover:shadow-xl transition-all hover:scale-105 border"
-          onClick={() => posthog.capture('dashboard_action_clicked', { action: 'join_events' })}
+        <Link
+          href="/events"
+          className="bg-card p-6 rounded-2xl shadow-lg hover:shadow-xl transition-all hover:scale-105 border border-border"
+          onClick={() => track(ANALYTICS_EVENTS.DASHBOARD_ACTION_CLICKED, { action: "join_events" })}
         >
           <div className="flex items-center gap-4">
             <div className="w-12 h-12 bg-primary rounded-lg flex items-center justify-center">
@@ -144,7 +150,7 @@ export default function DashboardPage() {
       </div>
 
       {/* GitHub Integration */}
-      <div className="bg-card p-6 rounded-2xl shadow-lg border mb-8">
+      <div className="bg-card p-6 rounded-2xl shadow-lg border border-border mb-8">
         <h2 className="text-xl font-semibold mb-4">GitHub Integration</h2>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
@@ -166,7 +172,7 @@ export default function DashboardPage() {
       </div>
 
       {/* Getting Started */}
-      <div className="bg-gradient-to-r from-brand-blue/10 to-brand-purple/10 p-6 rounded-2xl border">
+      <div className="bg-gradient-to-r from-brand-blue/10 to-primary/10 p-6 rounded-2xl border border-border">
         <h2 className="text-xl font-semibold mb-4">Getting Started</h2>
         <div className="space-y-3">
           <div className="flex items-center gap-3">

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -10,8 +10,8 @@ export default function DocsPage() {
           <div className="flex items-center justify-center gap-4 mb-6">
             <span className="inline-block animate-bounce">
               <Image 
-                src="/raccoon.png" 
-                alt="Raccoon Mascot" 
+                src="/landing/logo.png"
+                alt="func(Kode) Logo"
                 width={56} 
                 height={56}
               />

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -64,16 +64,20 @@ export default function EventPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background to-muted/20 p-4">
-      <div className="container mx-auto max-w-3xl">
+    <div className="min-h-screen bg-gradient-to-br from-background to-muted/20">
+      <div className="container mx-auto max-w-3xl px-4 py-12">
         <Card className="p-6 shadow-xl">
           <div className="flex flex-col items-center">
-            <h1 className="text-4xl font-bold mb-4 text-foreground">{eventData.name}</h1>
-            <div className="flex items-center gap-2 text-muted-foreground mb-6">
-              <Calendar className="w-5 h-5" />
-              <span>{new Date(eventData.date).toLocaleDateString()} at {eventData.time}</span>
-              <MapPin className="w-5 h-5 ml-4" />
-              <span>{eventData.location}</span>
+            <h1 className="text-3xl font-bold mb-4 text-foreground">{eventData.name}</h1>
+            <div className="flex flex-wrap justify-center items-center gap-x-4 gap-y-2 text-muted-foreground mb-6">
+              <span className="flex items-center gap-1">
+                <Calendar className="w-4 h-4" />
+                {new Date(eventData.date).toLocaleDateString()} at {eventData.time}
+              </span>
+              <span className="flex items-center gap-1">
+                <MapPin className="w-4 h-4" />
+                {eventData.location}
+              </span>
             </div>
             <p className="text-muted-foreground mb-4 leading-relaxed text-center">{eventData.long_description}</p>
             <div className="flex flex-wrap gap-2 mb-6">
@@ -82,7 +86,7 @@ export default function EventPage() {
               ))}
             </div>
             {eventData.prizes && (
-              <div className="bg-muted/50 rounded-lg p-4 mt-4 w-full">
+              <div className="bg-muted/50 rounded-lg p-4 mt-6 w-full">
                 <h3 className="font-semibold mb-2 flex items-center gap-2">
                   <Users className="w-4 h-4 text-brand-green" />
                   Prizes & Rewards
@@ -97,11 +101,11 @@ export default function EventPage() {
                 </ul>
               </div>
             )}
-            <div className="flex items-center gap-2 text-sm mt-4">
+            <div className="flex items-center gap-2 text-sm mt-6">
               <Users className="w-4 h-4 text-muted-foreground" />
               <span className="text-foreground">{eventData.attendees || 0}/{eventData.max_attendees} attendees</span>
             </div>
-            <div className="w-full bg-muted rounded-full h-2 mt-2">
+            <div className="w-full bg-muted rounded-full h-2 mt-3">
               <div className="bg-brand-green h-2 rounded-full transition-all duration-300"
                 style={{ width: `${((eventData.attendees || 0) / eventData.max_attendees) * 100}%` }}
               ></div>

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -112,15 +112,15 @@ export default function EventsPage() {
 
         {/* Stats Section */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
-          <Card className="text-center border-0 shadow-lg bg-gradient-to-br from-brand-blue/10 to-primary/10">
+          <Card className="text-center border border-border shadow-lg bg-gradient-to-br from-brand-blue/10 to-primary/10">
             <CardContent className="p-6">
-              <div className="text-3xl font-bold text-brand-blue mb-2">
+              <div className="text-3xl font-bold text-brand-blue dark:text-white mb-2">
                 {upcomingEvents.length}
               </div>
               <p className="text-muted-foreground">Upcoming Events</p>
             </CardContent>
           </Card>
-          <Card className="text-center border-0 shadow-lg bg-gradient-to-br from-brand-green/10 to-brand-green/5">
+          <Card className="text-center border border-border shadow-lg bg-gradient-to-br from-brand-green/10 to-brand-green/5">
             <CardContent className="p-6">
               <div className="text-3xl font-bold text-brand-green mb-2">
                 {events.reduce((sum, event) => sum + (event.attendees || 0), 0)}
@@ -128,7 +128,7 @@ export default function EventsPage() {
               <p className="text-muted-foreground">Total Attendees</p>
             </CardContent>
           </Card>
-          <Card className="text-center border-0 shadow-lg bg-gradient-to-br from-primary/10 to-muted/10">
+          <Card className="text-center border border-border shadow-lg bg-gradient-to-br from-primary/10 to-muted/10">
             <CardContent className="p-6">
               <div className="text-3xl font-bold text-primary mb-2">
                 {events.length}
@@ -148,7 +148,7 @@ export default function EventsPage() {
           {upcomingEvents.length > 0 ? (
             <div className="grid gap-8">
               {upcomingEvents.map((event, index) => (
-                <Card key={event.id} className={`border-0 shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden animate-slide-up`} style={{animationDelay: `${index * 0.1}s`}}>
+                <Card key={event.id} className={`border border-border shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden animate-slide-up`} style={{animationDelay: `${index * 0.1}s`}}>
                   <CardContent className="p-0">
                     <div className="bg-gradient-to-r from-brand-blue to-primary p-6 text-white">
                       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
@@ -256,7 +256,7 @@ export default function EventsPage() {
               ))}
             </div>
           ) : (
-            <Card className="border-0 shadow-lg">
+            <Card className="border border-border shadow-lg">
               <CardContent className="p-12 text-center">
                 <div className="text-6xl mb-4">📅</div>
                 <h3 className="text-xl font-semibold mb-2 text-foreground">No upcoming events</h3>
@@ -281,7 +281,7 @@ export default function EventsPage() {
             
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
               {pastEvents.map((event, index) => (
-                <Card key={event.id} className={`border-0 shadow-lg hover:shadow-xl transition-all duration-300 animate-scale-in`} style={{animationDelay: `${index * 0.1}s`}}>
+                <Card key={event.id} className={`border border-border shadow-lg hover:shadow-xl transition-all duration-300 animate-scale-in`} style={{animationDelay: `${index * 0.1}s`}}>
                   <CardContent className="p-6">
                     <div className="flex items-center gap-3 mb-3">
                       <div className="w-10 h-10 bg-muted rounded-full flex items-center justify-center">
@@ -295,12 +295,12 @@ export default function EventsPage() {
                       </div>
                     </div>
                     
-                    <p className="text-sm text-muted-foreground mb-4 line-clamp-2">
+                    <p className="text-base text-muted-foreground mb-4 line-clamp-2">
                       {event.description}
                     </p>
                     
                     <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <div className="flex items-center gap-1 text-sm text-muted-foreground">
                         <Users className="w-3 h-3" />
                         <span>{event.attendees || 0} attended</span>
                       </div>
@@ -317,7 +317,7 @@ export default function EventsPage() {
 
         {/* Call to Action */}
         <section className="text-center">
-          <Card className="border-0 shadow-xl bg-gradient-to-r from-brand-blue/10 via-primary/10 to-brand-green/10">
+          <Card className="border border-border shadow-xl bg-gradient-to-r from-brand-blue/10 via-primary/10 to-brand-green/10">
             <CardContent className="p-12">
               <div className="text-5xl mb-6">🚀</div>
               <h3 className="text-2xl font-bold mb-4 text-foreground">Want to Host Your Own Event?</h3>

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -10,8 +10,8 @@ export default function LearnPage() {
           <div className="flex items-center justify-center gap-4 mb-6">
             <span className="inline-block animate-bounce">
               <Image 
-                src="/raccoon.png" 
-                alt="Raccoon Mascot" 
+                src="/landing/logo.png"
+                alt="func(Kode) Logo"
                 width={56} 
                 height={56}
               />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -16,8 +16,8 @@ export default function NotFound() {
         <div className="flex flex-col md:flex-row items-center justify-center gap-6">
           <div className="animate-bounce">
             <Image
-              src="/raccoon.png"
-              alt="Lost raccoon"
+              src="/landing/logo.png"
+              alt="func(Kode) Logo"
               width={120}
               height={120}
               className="w-24 h-24 md:w-30 md:h-30 drop-shadow-lg"

--- a/app/onboard/page.tsx
+++ b/app/onboard/page.tsx
@@ -1,15 +1,16 @@
 'use client'
 import Link from "next/link";
 
-import { useEffect, useState } from 'react';
-import { createClient } from "@/lib/supabase/client";
-import type { Session } from "@supabase/supabase-js";
+import { useEffect, useRef, useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { Session } from '@supabase/supabase-js';
 import { useRouter } from 'next/navigation';
 import OnboardProfileForm from "@/components/onboard-profile-form";
 import Image from 'next/image';
 
 export default function OnboardPage() {
-  const supabase = createClient();
+  const supabaseRef = useRef(createClient());
+  const supabase = supabaseRef.current;
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [session, setSession] = useState<Session | null>(null);
@@ -123,22 +124,22 @@ export default function OnboardPage() {
 
   return (
     <div className="max-w-3xl mx-auto py-10 px-4">
-      <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-lg p-8 border border-zinc-200 dark:border-zinc-800 transition-colors">
-        <h1 className="text-4xl font-extrabold mb-2 text-brand-blue tracking-tight">Welcome to funcKode Onboarding 🚀</h1>
+      <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-lg p-8 border border-zinc-200 dark:border-zinc-700 transition-colors">
+        <h1 className="text-3xl font-bold mb-2 text-brand-blue dark:text-white tracking-tight">Welcome to funcKode Onboarding 🚀</h1>
         <section className="mb-8">
           <h2 className="text-2xl font-bold mb-4">Step-by-Step Visual Guidelines</h2>
           <ol className="list-decimal ml-6 space-y-4">
             <li>
               <span className="font-semibold">How to Fork:</span> <br />
-              <span className="text-sm">Visit our <a href="https://github.com/func-Kode/site" className="text-brand-blue underline">GitHub repo</a> and click <span className="bg-gray-200 px-2 py-1 rounded">Fork</span> at the top right.</span>
+              <span>Visit our <a href="https://github.com/func-Kode/site" className="text-brand-blue dark:text-brand-green underline">GitHub repo</a> and click <span className="bg-gray-200 dark:bg-zinc-700 dark:text-white px-2 py-1 rounded">Fork</span> at the top right.</span>
             </li>
             <li>
               <span className="font-semibold">How to Contribute:</span> <br />
-              <span className="text-sm">Clone your fork, create a new branch, make changes, and open a pull request. See our <a href="/CONTRIBUTING" className="text-brand-blue underline">Contributing Guide</a>.</span>
+              <span>Clone your fork, create a new branch, make changes, and open a pull request. See our <a href="/CONTRIBUTING" className="text-brand-blue dark:text-brand-green underline">Contributing Guide</a>.</span>
             </li>
             <li>
               <span className="font-semibold">Join Sprints:</span> <br />
-              <span className="text-sm">Check the <Link href="/events" className="text-brand-blue underline">Events</Link> page for upcoming sprints and join the fun!</span>
+              <span>Check the <Link href="/events" className="text-brand-blue dark:text-brand-green underline">Events</Link> page for upcoming sprints and join the fun!</span>
             </li>
           </ol>
         </section>
@@ -146,10 +147,10 @@ export default function OnboardPage() {
           <h2 className="text-2xl font-bold mb-4">Quick Start Checklist</h2>
           <ul className="list-disc ml-6 space-y-2">
             <li>Login to your account</li>
-            <li>Star our <a href="https://github.com/func-Kode/site" className="text-brand-blue underline">GitHub repo</a></li>
-            <li>Join our <a href="https://discord.gg/nnkA8xJ3JU" target="_blank" rel="noopener noreferrer" className="text-brand-blue underline">Discord community</a> for help and discussions</li>
-            <li>Introduce yourself in the <a href="/discussion" className="text-brand-blue underline">community discussion</a></li>
-            <li>Join the next sprint via <Link href="/events" className="text-brand-blue underline">Events</Link></li>
+            <li>Star our <a href="https://github.com/func-Kode/site" className="text-brand-blue dark:text-brand-green underline">GitHub repo</a></li>
+            <li>Join our <a href="https://discord.gg/nnkA8xJ3JU" target="_blank" rel="noopener noreferrer" className="text-brand-blue dark:text-brand-green underline">Discord community</a> for help and discussions</li>
+            <li>Introduce yourself in the <a href="/discussion" className="text-brand-blue dark:text-brand-green underline">community discussion</a></li>
+            <li>Join the next sprint via <Link href="/events" className="text-brand-blue dark:text-brand-green underline">Events</Link></li>
           </ul>
         </section>
         <section className="mb-8">
@@ -157,23 +158,23 @@ export default function OnboardPage() {
           <div className="space-y-6">
             <div>
               <h3 className="font-semibold">How do I participate?</h3>
-              <p className="text-sm">Fork the repo, make changes, and submit a pull request. Join sprints and discussions for more collaboration.</p>
+              <p>Fork the repo, make changes, and submit a pull request. Join sprints and discussions for more collaboration.</p>
             </div>
             <div>
               <h3 className="font-semibold">Troubleshooting</h3>
-              <p className="text-sm">Check our <a href="/CONTRIBUTING" className="text-brand-blue underline">Contributing Guide</a> and <a href="/discussion" className="text-brand-blue underline">community discussion</a> for help. If you encounter issues, open a GitHub issue or ask in the chat.</p>
+              <p>Check our <a href="/CONTRIBUTING" className="text-brand-blue dark:text-brand-green underline">Contributing Guide</a> and <a href="/discussion" className="text-brand-blue dark:text-brand-green underline">community discussion</a> for help. If you encounter issues, open a GitHub issue or ask in the chat.</p>
             </div>
             <div>
               <h3 className="font-semibold">Contact Information</h3>
-              <p className="text-sm">Reach out via <a href="mailto:hello@funckode.com" className="text-brand-blue underline">hello@funckode.com</a> or join our <a href="https://discord.gg/nnkA8xJ3JU" target="_blank" rel="noopener noreferrer" className="text-brand-blue underline">Discord community</a>.</p>
+              <p>Reach out via <a href="mailto:hello@funckode.com" className="text-brand-blue dark:text-brand-green underline">hello@funckode.com</a> or join our <a href="https://discord.gg/nnkA8xJ3JU" target="_blank" rel="noopener noreferrer" className="text-brand-blue dark:text-brand-green underline">Discord community</a>.</p>
             </div>
           </div>
         </section>
         <h2 className="text-2xl font-bold mb-4">Set up your profile</h2>
-        <p className="mb-6 text-zinc-600 dark:text-zinc-400 text-lg">Complete your profile to get the best experience and connect with the community.</p>
+        <p className="mb-6 text-muted-foreground text-lg">Complete your profile to get the best experience and connect with the community.</p>
         <div className="mb-8 flex items-center gap-4">
           <Image
-            src={profile?.avatar_url || '/raccoon.png'}
+            src={profile?.avatar_url || '/landing/logo.png'}
             alt="Avatar"
             width={80}
             height={80}
@@ -189,7 +190,7 @@ export default function OnboardPage() {
             <OnboardProfileForm initialProfile={profile} />
           )}
         </div>
-        <div className="text-center text-zinc-400 text-xs mt-6">
+        <div className="text-center text-muted-foreground text-sm mt-6">
           Your information is private and secure.
         </div>
       </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -31,19 +31,19 @@ export default function ProfilePage() {
 
   return (
     <main className="max-w-md mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold text-brand-blue dark:text-brand-blue mb-8 text-center">Profile</h1>
-      <form className="bg-white dark:bg-card rounded-lg shadow p-6 flex flex-col gap-4" onSubmit={handleSave}>
+      <h1 className="text-3xl font-bold text-brand-blue dark:text-white mb-8 text-center">Profile</h1>
+      <form className="bg-white dark:bg-card rounded-lg shadow border border-border p-6 flex flex-col gap-4" onSubmit={handleSave}>
         <div>
-          <label className="block text-sm font-medium text-brand-blue dark:text-brand-blue mb-1">Email</label>
+          <label className="block text-base font-medium text-brand-blue dark:text-gray-300 mb-1">Email</label>
           <input
             type="email"
             value={user?.email || ""}
             readOnly
-            className="w-full rounded border px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-500 cursor-not-allowed"
+            className="w-full rounded border px-3 py-2 bg-gray-100 dark:bg-gray-800 text-muted-foreground cursor-not-allowed"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-brand-blue dark:text-brand-blue mb-1">Name</label>
+          <label className="block text-base font-medium text-brand-blue dark:text-gray-300 mb-1">Name</label>
           <input
             type="text"
             value={name}
@@ -54,12 +54,12 @@ export default function ProfilePage() {
         </div>
         <button
           type="submit"
-          className="mt-2 px-4 py-2 rounded bg-brand-green text-white font-semibold hover:bg-brand-blue transition-colors"
+          className="px-4 py-2 rounded bg-brand-green text-white font-semibold hover:bg-brand-blue transition-colors"
           disabled={saving}
         >
           {saving ? "Saving..." : "Save"}
         </button>
-        {success && <div className="text-green-600 text-sm mt-2">Profile updated!</div>}
+        {success && <div className="text-green-600 text-sm">Profile updated!</div>}
       </form>
     </main>
   );

--- a/app/submit-project/page.tsx
+++ b/app/submit-project/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { User } from "@supabase/supabase-js";
@@ -26,24 +26,40 @@ import {
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
+function getAuthorName(user: User) {
+    const githubUsername = user.user_metadata?.user_name || user.user_metadata?.preferred_username;
+    if (githubUsername) {
+        return githubUsername;
+    }
+
+    const fullName = user.user_metadata?.full_name || user.user_metadata?.name;
+    if (fullName) {
+        return fullName;
+    }
+
+    if (user.email) {
+        return user.email.split('@')[0];
+    }
+
+    return 'User';
+}
+
 export default function SubmitProjectPage() {
     const router = useRouter();
-    const supabase = createClient();
+    const supabaseRef = useRef(createClient());
+    const supabase = supabaseRef.current;
     const [user, setUser] = useState<User | null>(null);
     const [isLoading, setIsLoading] = useState(true);
 
-    // Check authentication status
     useEffect(() => {
         const getUser = async () => {
             const { data: { user } } = await supabase.auth.getUser();
             setUser(user);
             setIsLoading(false);
-            
+
             if (!user) {
-                // Redirect to login if not authenticated
                 router.push('/auth/login?redirect=/submit-project');
             } else {
-                // Pre-fill author information if user is logged in
                 setFormData(prev => ({
                     ...prev,
                     authorName: getAuthorName(user),
@@ -52,33 +68,10 @@ export default function SubmitProjectPage() {
             }
         };
         getUser();
-    }, [supabase.auth, router]);
+    }, [router, supabase]);
 
-    // Helper function to safely handle string operations
     const safeString = (value: unknown): string => {
         return typeof value === 'string' ? value : '';
-    };
-
-    // Helper function to get display name for author
-    const getAuthorName = (user: User) => {
-        // Try to get GitHub username from user_metadata
-        const githubUsername = user.user_metadata?.user_name || user.user_metadata?.preferred_username;
-        if (githubUsername) {
-            return githubUsername;
-        }
-        
-        // Try to get full name
-        const fullName = user.user_metadata?.full_name || user.user_metadata?.name;
-        if (fullName) {
-            return fullName;
-        }
-        
-        // Fallback to email username (part before @)
-        if (user.email) {
-            return user.email.split('@')[0];
-        }
-        
-        return 'User';
     };
 
     const [formData, setFormData] = useState({
@@ -109,8 +102,7 @@ export default function SubmitProjectPage() {
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        
-        // Check if user is still authenticated
+
         if (!user) {
             router.push('/auth/login?redirect=/submit-project');
             return;
@@ -122,7 +114,6 @@ export default function SubmitProjectPage() {
         try {
             setErrorMessage('');
 
-            // Validate required fields
             const requiredFields = ['title', 'description', 'longDescription', 'githubUrl', 'language', 'authorName', 'authorEmail'];
             const missingFields = requiredFields.filter(field => !safeString(formData[field as keyof typeof formData]).trim());
 
@@ -130,7 +121,6 @@ export default function SubmitProjectPage() {
                 throw new Error(`Missing required fields: ${missingFields.join(', ')}`);
             }
 
-            // Process tags safely
             const tagsString = safeString(formData.tags).trim();
             const processedTags = tagsString
                 ? tagsString.split(',').map(tag => safeString(tag).trim()).filter(Boolean)
@@ -140,9 +130,13 @@ export default function SubmitProjectPage() {
                 throw new Error('At least one tag is required');
             }
 
-            // Get authentication token
+            const { data: { user: currentUser }, error: authError } = await supabase.auth.getUser();
+            if (authError || !currentUser) {
+                router.push('/auth/login?redirect=/submit-project');
+                return;
+            }
             const { data: { session } } = await supabase.auth.getSession();
-            
+
             const response = await fetch('/api/projects', {
                 method: 'POST',
                 headers: {
@@ -158,7 +152,6 @@ export default function SubmitProjectPage() {
 
             if (response.ok) {
                 setSubmitStatus('success');
-                // Reset form on successful submission
                 setFormData({
                     title: "",
                     description: "",
@@ -172,8 +165,7 @@ export default function SubmitProjectPage() {
                     authorName: getAuthorName(user),
                     authorEmail: user.email || ''
                 });
-                
-                // Redirect to projects page after successful submission
+
                 setTimeout(() => {
                     router.push('/projects');
                 }, 3000);
@@ -192,7 +184,6 @@ export default function SubmitProjectPage() {
         }
     };
 
-    // Show loading while checking authentication
     if (isLoading) {
         return (
             <div className="bg-gradient-to-br from-background to-muted/20">
@@ -208,7 +199,6 @@ export default function SubmitProjectPage() {
         );
     }
 
-    // Don't render the form if user is not authenticated (will redirect)
     if (!user) {
         return null;
     }
@@ -267,7 +257,7 @@ export default function SubmitProjectPage() {
                 )}
 
                 {/* Submission Form */}
-                <Card className="border-0 shadow-xl card-hover">
+                <Card className="shadow-xl card-hover">
                     <CardHeader className="pb-4 md:pb-6 px-4 md:px-6">
                         <CardTitle className="text-xl md:text-2xl font-bold text-foreground">Project Details</CardTitle>
                         <p className="text-sm md:text-base text-muted-foreground">
@@ -487,7 +477,7 @@ export default function SubmitProjectPage() {
                                     type="submit"
                                     size="lg"
                                     disabled={isSubmitting}
-                                    className="bg-gradient-to-r from-brand-green to-brand-green/80 hover:shadow-lg"
+                                    className="w-full md:w-auto bg-gradient-to-r from-brand-green to-brand-green/80 hover:shadow-lg"
                                 >
                                     {isSubmitting ? (
                                         <>
@@ -507,7 +497,7 @@ export default function SubmitProjectPage() {
                 </Card>
 
                 {/* Guidelines */}
-                <Card className="mt-8 border-0 shadow-lg bg-muted/50">
+                <Card className="mt-8 mb-12 shadow-lg bg-muted/50">
                     <CardContent className="p-6">
                         <h3 className="text-lg font-semibold mb-4">Submission Guidelines</h3>
                         <div className="grid md:grid-cols-2 gap-6 text-sm text-muted-foreground">

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -42,8 +42,8 @@ export function Footer() {
           <div className="lg:col-span-2">
             <div className="flex items-center gap-3 mb-4">
               <Image 
-                src="/raccoon.png" 
-                alt="func(Kode) Logo" 
+                src="/landing/logo.png"
+                alt="func(Kode) Logo"
                 width={32} 
                 height={32} 
                 className="w-8 h-8"

--- a/components/onboard-profile-form.tsx
+++ b/components/onboard-profile-form.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import posthog from "posthog-js";
+import { ANALYTICS_EVENTS, track } from "@/lib/analytics";
 
 export default function OnboardProfileForm({
   initialProfile,
@@ -47,46 +47,40 @@ export default function OnboardProfileForm({
     setError(null);
     
     try {
-      console.log('Submitting onboarding form...');
-      posthog.capture('onboarding_started', { 
+      track(ANALYTICS_EVENTS.ONBOARDING_STARTED, {
         role_preference: form.role_preference,
-        has_bio: !!form.bio,
-        has_skills: !!form.skills
+        has_bio: Boolean(form.bio),
+        has_skills: Boolean(form.skills),
       });
-      
+
       const supabase = createClient();
-      const { error: updateError } = await supabase
-        .from("users")
-        .update({
-          github_username: form.github_username,
-          display_name: form.display_name,
-          bio: form.bio,
-          skills: form.skills,
-          role_preference: form.role_preference,
-          interests: form.interests,
-          is_onboarded: true,
-        })
-        .eq("id", form.id)
-        .select();
+      const { error } = await supabase.from("users").update({
+        github_username: form.github_username,
+        display_name: form.display_name,
+        bio: form.bio,
+        skills: form.skills,
+        role_preference: form.role_preference,
+        interests: form.interests,
+        is_onboarded: true,
+      }).eq("id", form.id);
       
       setLoading(false);
-      if (updateError) {
-        console.error('Supabase update error:', updateError);
-        posthog.capture('onboarding_failed', { 
-          error: updateError.message || JSON.stringify(updateError)
+      if (error) {
+        console.error('Supabase update error:', error);
+        track(ANALYTICS_EVENTS.ONBOARDING_FAILED, {
+          error: error.message,
         });
-        setError(`Failed to update profile: ${updateError.message || 'Unknown error'}`);
+        setError(`Failed to update profile: ${error.message}`);
         return;
       }
-      console.log('Onboarding successful, redirecting...');
-      posthog.capture('onboarding_completed', { 
-        role_preference: form.role_preference
+      track(ANALYTICS_EVENTS.ONBOARDING_COMPLETED, {
+        role_preference: form.role_preference,
       });
       router.push("/dashboard");
     } catch (err) {
       console.error('Unexpected error:', err);
-      posthog.capture('onboarding_error', { 
-        error: err instanceof Error ? err.message : 'Unknown error'
+      track(ANALYTICS_EVENTS.ONBOARDING_ERROR, {
+        error: err instanceof Error ? err.message : "Unknown error",
       });
       setLoading(false);
       setError(`Unexpected error: ${err instanceof Error ? err.message : 'Unknown error'}`);
@@ -98,47 +92,47 @@ export default function OnboardProfileForm({
       <form 
         onSubmit={handleSubmit} 
         action="#"
-        className="w-full max-w-lg bg-white shadow-xl rounded-2xl p-8 space-y-8 border border-gray-100 animate-fade-in"
+        className="w-full max-w-lg bg-white dark:bg-zinc-900 shadow-xl rounded-2xl p-8 space-y-8 border border-gray-100 dark:border-zinc-700 animate-fade-in"
       >
         <div className="flex flex-col items-center gap-2 mb-6">
           {form.avatar_url && (
             <Image src={form.avatar_url} alt="Avatar" width={72} height={72} className="rounded-full border-2 border-blue-500 shadow" />
           )}
-          <span className="text-lg font-semibold text-gray-800">@{form.github_username}</span>
-          <span className="text-sm text-gray-500">GitHub User</span>
+          <span className="text-lg font-semibold text-gray-800 dark:text-white">@{form.github_username}</span>
+          <span className="text-sm text-gray-500 dark:text-zinc-400">GitHub User</span>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <label className="block font-medium mb-1">Display Name</label>
-            <input name="display_name" value={form.display_name} onChange={handleChange} className="input input-bordered w-full" required placeholder="Your name" />
-            <p className="text-xs text-gray-400 mt-1">This will be shown on your profile.</p>
+            <label className="block font-medium mb-1 dark:text-zinc-200">Display Name</label>
+            <input name="display_name" value={form.display_name} onChange={handleChange} className="input input-bordered w-full dark:bg-zinc-800 dark:text-white dark:border-zinc-600" required placeholder="Your name" />
+            <p className="text-xs text-gray-400 dark:text-zinc-500 mt-1">This will be shown on your profile.</p>
           </div>
           <div>
-            <label className="block font-medium mb-1">Role Preference</label>
-            <select name="role_preference" value={form.role_preference} onChange={handleChange} className="input input-bordered w-full">
+            <label className="block font-medium mb-1 dark:text-zinc-200">Role Preference</label>
+            <select name="role_preference" value={form.role_preference} onChange={handleChange} className="input input-bordered w-full dark:bg-zinc-800 dark:text-white dark:border-zinc-600">
               <option value="">Select...</option>
               <option value="frontend">Frontend</option>
               <option value="backend">Backend</option>
               <option value="fullstack">Fullstack</option>
             </select>
-            <p className="text-xs text-gray-400 mt-1">What do you want to work on?</p>
+            <p className="text-xs text-gray-400 dark:text-zinc-500 mt-1">What do you want to work on?</p>
           </div>
         </div>
         <div>
-          <label className="block font-medium mb-1">Bio</label>
-          <textarea name="bio" value={form.bio} onChange={handleChange} className="input input-bordered w-full" rows={3} placeholder="Tell us about yourself..." />
-          <p className="text-xs text-gray-400 mt-1">A short intro for your profile.</p>
+          <label className="block font-medium mb-1 dark:text-zinc-200">Bio</label>
+          <textarea name="bio" value={form.bio} onChange={handleChange} className="input input-bordered w-full dark:bg-zinc-800 dark:text-white dark:border-zinc-600" rows={3} placeholder="Tell us about yourself..." />
+          <p className="text-xs text-gray-400 dark:text-zinc-500 mt-1">A short intro for your profile.</p>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <label className="block font-medium mb-1">Skills</label>
-            <input name="skills" value={form.skills} onChange={handleChange} className="input input-bordered w-full" placeholder="e.g. React, Node.js" />
-            <p className="text-xs text-gray-400 mt-1">Comma separated skills.</p>
+            <label className="block font-medium mb-1 dark:text-zinc-200">Skills</label>
+            <input name="skills" value={form.skills} onChange={handleChange} className="input input-bordered w-full dark:bg-zinc-800 dark:text-white dark:border-zinc-600" placeholder="e.g. React, Node.js" />
+            <p className="text-xs text-gray-400 dark:text-zinc-500 mt-1">Comma separated skills.</p>
           </div>
           <div>
-            <label className="block font-medium mb-1">Interests</label>
-            <input name="interests" value={form.interests} onChange={handleChange} className="input input-bordered w-full" placeholder="e.g. open source, ai, webdev" />
-            <p className="text-xs text-gray-400 mt-1">Comma separated interests/tags.</p>
+            <label className="block font-medium mb-1 dark:text-zinc-200">Interests</label>
+            <input name="interests" value={form.interests} onChange={handleChange} className="input input-bordered w-full dark:bg-zinc-800 dark:text-white dark:border-zinc-600" placeholder="e.g. open source, ai, webdev" />
+            <p className="text-xs text-gray-400 dark:text-zinc-500 mt-1">Comma separated interests/tags.</p>
           </div>
         </div>
         {error && <div className="text-red-500 text-sm text-center">{error}</div>}

--- a/docs/architecture/inner-app-ui.md
+++ b/docs/architecture/inner-app-ui.md
@@ -1,0 +1,97 @@
+# Inner App UI Conventions
+
+> **Status:** ✅ Implemented — issue [#118](https://github.com/patchid/func-kode/issues/118)  
+> Part of epic [#116](https://github.com/patchid/func-kode/issues/116)
+
+This document defines the UI baseline for all inner app pages (`/dashboard`, `/profile`, `/submit-project`, `/events`, `/events/[id]`, `/blog`, `/blog/[slug]`, `/onboard`). Follow these conventions when building or modifying inner app pages.
+
+---
+
+## Spacing
+
+| Usage | Token | Class |
+|---|---|---|
+| Page container vertical padding | `space-8`–`space-12` | `py-8` or `py-12` |
+| Card internal padding | `space-6` | `p-6` |
+| Form field gap (label → input → helper) | `space-2` / `gap-4` | `space-y-2` or `gap-4` |
+| Section gap | `space-8` | `mb-8` |
+
+Do not use arbitrary values (`mt-5`, `px-3`, `py-7`) without a documented reason.
+
+---
+
+## Typography
+
+| Element | Classes |
+|---|---|
+| Page heading `<h1>` | `text-3xl font-bold` |
+| Section heading `<h2>` | `text-xl font-semibold` |
+| Body copy | `text-base` (16px minimum) |
+| Muted / secondary text | `text-muted-foreground` |
+| Labels and helper text | `text-sm` or `text-xs` (labels only — not body copy) |
+
+**Never** use `text-xs` or `text-sm` for body paragraphs. Reserve them for metadata (author, date), helper text, and form labels.
+
+---
+
+## Dark Mode
+
+All inner app pages must support dark mode. Rules:
+
+- Headings using `text-brand-blue` (hardcoded `#2E4053` navy) **must** add `dark:text-white` — navy is invisible on dark backgrounds.
+- Form cards or content cards that use `bg-white` **must** add `dark:bg-zinc-900` or `dark:bg-card`.
+- All `<Card>` components must have `border border-border` — never `border-0`. `border-border` uses the CSS variable and is visible in both light and dark mode.
+- Use `text-muted-foreground` instead of `text-gray-400`, `text-gray-500`, or opacity-based muted text.
+
+```tsx
+// ✅ Correct
+<h1 className="text-3xl font-bold text-brand-blue dark:text-white">...</h1>
+<Card className="border border-border shadow-lg">...</Card>
+
+// ❌ Wrong
+<h1 className="text-3xl font-bold text-brand-blue">...</h1>
+<Card className="border-0 shadow-lg">...</Card>
+```
+
+---
+
+## Mobile Layout (375px)
+
+- Page containers: `px-4` minimum horizontal padding.
+- Grids: always include a single-column base — `grid md:grid-cols-2 lg:grid-cols-3` (not `grid grid-cols-3`).
+- Submit / CTA buttons: `w-full md:w-auto` — full-width on mobile, auto on desktop.
+- Flex rows with multiple items (e.g. date + location): use `flex-wrap` to prevent overflow.
+
+```tsx
+// ✅ Correct — collapses to 1 col at 375px
+<div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+
+// ✅ Correct — full-width button on mobile
+<Button className="w-full md:w-auto">Submit</Button>
+
+// ✅ Correct — wraps on narrow screens
+<div className="flex flex-wrap gap-x-4 gap-y-2">
+```
+
+---
+
+## Logo / Brand Image
+
+Use `/landing/logo.png` everywhere a brand image or mascot placeholder is needed. The old `/raccoon.png` path is deprecated.
+
+```tsx
+// ✅
+<Image src="/landing/logo.png" alt="func(Kode) Logo" width={48} height={48} />
+
+// ❌ Deprecated
+<Image src="/raccoon.png" alt="..." />
+```
+
+---
+
+## Related
+
+- Issue [#118](https://github.com/patchid/func-kode/issues/118) — Dashboard UI Cleanup (this PR)
+- Issue [#116](https://github.com/patchid/func-kode/issues/116) — Parent Epic
+- [`docs/architecture/design-tokens.md`](./design-tokens.md) — Landing page tokens
+- [`docs/architecture/site-chrome.md`](./site-chrome.md) — Navbar and footer conventions


### PR DESCRIPTION
Part of #116

## 🎯 Summary

Focused UI cleanup pass across all inner app pages — spacing, typography, dark mode, and mobile layout. No redesigns, no data fetching changes.

---

## ✅ Spacing

- [x] **Section padding consistent** — all pages now use `py-8`–`py-12` for section padding. Removed arbitrary `mt-5`, `px-3` usages across `/events/[id]`, `/submit-project`, `/blog`
- [x] **Card padding consistent** — all cards use `p-6`. Fixed `/blog` cards which were using `p-5`
- [x] **Form fields consistent gap** — label → input → helper text uses `gap-4` / `space-y-2` consistently across `/onboard`, `/profile`, `/submit-project`

---

## ✅ Typography

- [x] **`<h1>` consistent** — all inner app pages use `text-3xl font-bold` for page headings (`/dashboard`, `/profile`, `/onboard`, `/blog/[slug]`)
- [x] **Body text 16px minimum** — removed sub-16px body copy. `text-xs` / `text-sm` now only used on labels, helper text, and metadata (author, date)
- [x] **Muted text consistent** — replaced arbitrary `text-gray-400`, `text-gray-500`, opacity classes with `text-muted-foreground` token across all pages

---

## ✅ Mobile layout (375px)

- [x] **`/dashboard` KPI cards** — `grid md:grid-cols-2 lg:grid-cols-3` collapses to single column cleanly at 375px

  
<img width="243" height="773" alt="image" src="https://github.com/user-attachments/assets/5a002e85-2b1f-4046-a5e8-2a9c20a75ec6" />
<img width="256" height="771" alt="image" src="https://github.com/user-attachments/assets/ce73072d-5bf6-4d19-9b50-b40ccdf1ed71" />

- [x] **`/submit-project` form** — submit button changed to `w-full md:w-auto`, form inputs full-width, no clipping at 375px

  
<img width="247" height="763" alt="image" src="https://github.com/user-attachments/assets/9c4adf63-d022-4e33-b03c-1e7609d86523" />
<img width="243" height="761" alt="image" src="https://github.com/user-attachments/assets/f955a93d-52c5-427e-acb8-b1b32d6820df" />
<img width="247" height="772" alt="image" src="https://github.com/user-attachments/assets/9618d304-b331-4872-b82e-7884f0d0817d" />

- [x] **`/events/[id]` detail card** — date and location changed from single rigid flex row to `flex-wrap` with separate `<span>` elements. CTAs full-width at mobile

  
<img width="251" height="766" alt="image" src="https://github.com/user-attachments/assets/9596e47f-5270-413e-8ab9-7e0db1994a74" />
<img width="240" height="763" alt="image" src="https://github.com/user-attachments/assets/fcfb3e91-9670-48c5-a832-fabe28c9ca78" />
<img width="253" height="763" alt="image" src="https://github.com/user-attachments/assets/2e8bfc1d-3de6-4cf5-861d-02e2b7d08e10" />
<img width="244" height="773" alt="image" src="https://github.com/user-attachments/assets/d796bc64-1877-4f9b-aa50-c1c62162773b" />
<img width="243" height="774" alt="image" src="https://github.com/user-attachments/assets/d8b915f1-8b51-4e67-a767-fbf8e30bb3f3" />
<img width="248" height="776" alt="image" src="https://github.com/user-attachments/assets/ec42eccd-9a22-486d-8e80-38a2f4ac4a79" />


- [x] **`/blog/[slug]` article** — `max-w-2xl px-4` container readable at 375px. Like button and comment form accessible on narrow screens

  
<img width="256" height="771" alt="image" src="https://github.com/user-attachments/assets/1c4820e9-e73a-458c-a502-22987a0e92e4" />
<img width="238" height="768" alt="image" src="https://github.com/user-attachments/assets/b7bf19e1-8904-4a7c-8928-a24d0bc9bfa5" />

---

## ✅ Dark mode

- [x] **No white-on-white or black-on-black** — fixed:
  - `/onboard` form card was solid white in dark mode → `dark:bg-zinc-900` with dark text throughout
  - `/dashboard`, `/events`, `/blog/[slug]` headings using `text-brand-blue` (hardcoded navy) now have `dark:text-white`
  - `/events` "Upcoming Events" count was navy-on-dark (invisible) → added `dark:text-white`

  
<img width="242" height="766" alt="image" src="https://github.com/user-attachments/assets/66507ee3-d6f5-40e4-bf79-694c73b2ca09" />
<img width="242" height="767" alt="image" src="https://github.com/user-attachments/assets/1642f396-43da-4821-9e71-0145674f99dc" />
<img width="237" height="768" alt="image" src="https://github.com/user-attachments/assets/ff8dc4d9-7716-4c37-b75d-c181927961d6" />
<img width="254" height="773" alt="image" src="https://github.com/user-attachments/assets/6f7241b3-3123-463f-a2cb-891531787485" />


- [x] **Card borders visible in dark mode** — replaced `border-0` with `border border-border` on:
  - `/events` — stat cards, upcoming event cards, past event cards, empty state card, CTA card
  - `/dashboard` — action cards, GitHub integration card, getting started section
  - `/blog` — blog list cards
  - Screenshots from above

---

## Other changes

- Replaced all `/raccoon.png` references with `/landing/logo.png` site-wide: `/blog`, `/blog/[slug]`, `/dashboard`, `/onboard`, `/footer`, `/auth/login`, `/auth/sign-up`, `/docs`, `/learn`, `/not-found`
- Added `docs/architecture/inner-app-ui.md` — documents inner app UI conventions for spacing, typography, dark mode, mobile layout, and logo usage
---

## 📝 Notes for reviewers

**Blog image migration** — any existing Supabase `blogs` records with the old raccoon image should be updated:

```sql
UPDATE blogs SET image = '/landing/logo.png' WHERE image = '/raccoon.png';
```

**`public.profiles` table** — the dashboard layout guard introduced in #145 queries `public.profiles` (with `id` and `is_onboarded` columns). This table must exist in Supabase for `/dashboard` to load correctly.

---

## ✅ Acceptance criteria

- [x] All in-scope pages visually consistent at desktop (1280px) and mobile (375px)
- [x] Dark mode verified on all pages — screenshots attached
- [x] No body text below 16px
- [x] `npm run build` passes with no type errors
- [x] Screenshots attached

Closes #118