### PR TITLE
feat(scoring): v1 scoring formula, sufficiency engine, types & DB migration

### DIFF
--- a/database/developer_scores.sql
+++ b/database/developer_scores.sql
@@ -1,0 +1,105 @@
+-- =============================================================================
+-- developer_scores
+-- Stores versioned Patch ID trust score snapshots per developer.
+-- Computed by lib/scoring/compute-developer-score.ts after each pr_event write.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS developer_scores (
+    id                         UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+
+    -- FK to auth.users (same as profiles.id)
+    developer_id               UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+    -- formula version — bump SCORE_VERSION in scoring-types.ts when weights change
+    score_version              INTEGER NOT NULL DEFAULT 1,
+
+    -- final trust score 0-100
+    score_total                NUMERIC(5,2) NOT NULL CHECK (score_total >= 0 AND score_total <= 100),
+
+    -- per-dimension scores (each 0-100 contribution after weighting)
+    merge_quality_score        NUMERIC(5,2) NOT NULL DEFAULT 0,
+    review_participation_score NUMERIC(5,2) NOT NULL DEFAULT 0,
+    consistency_score          NUMERIC(5,2) NOT NULL DEFAULT 0,
+    pr_hygiene_score           NUMERIC(5,2) NOT NULL DEFAULT 0,
+    recent_activity_score      NUMERIC(5,2) NOT NULL DEFAULT 0,
+
+    -- raw metrics snapshot used to compute this score (for auditability)
+    metrics_json               JSONB,
+
+    -- whether enough data existed at compute time
+    sufficient_data            BOOLEAN NOT NULL DEFAULT false,
+
+    -- short human-readable explanation surfaced in the UI
+    explanation                TEXT,
+
+    computed_at                TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    created_at                 TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+
+-- primary lookup: latest score for a developer
+CREATE INDEX IF NOT EXISTS idx_developer_scores_developer_id
+    ON developer_scores(developer_id);
+
+-- time-series queries (score history)
+CREATE INDEX IF NOT EXISTS idx_developer_scores_computed_at
+    ON developer_scores(developer_id, computed_at DESC);
+
+-- version-aware lookups
+CREATE INDEX IF NOT EXISTS idx_developer_scores_version
+    ON developer_scores(developer_id, score_version);
+
+-- ---------------------------------------------------------------------------
+-- Row Level Security
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE developer_scores ENABLE ROW LEVEL SECURITY;
+
+-- Developers can read their own scores
+CREATE POLICY "Users can view their own scores"
+ON developer_scores FOR SELECT
+TO authenticated
+USING (auth.uid() = developer_id);
+
+-- Only the service role (backend worker) can insert/update scores
+-- No authenticated user policy for INSERT — scores are written server-side only
+CREATE POLICY "Service role can manage scores"
+ON developer_scores FOR ALL
+TO service_role
+USING (true)
+WITH CHECK (true);
+
+-- Admins can view all scores
+CREATE POLICY "Admins can view all scores"
+ON developer_scores FOR SELECT
+TO authenticated
+USING (
+    auth.jwt() ->> 'email' IN ('vvs.pedapati@rediffmail.com') OR
+    auth.jwt() -> 'user_metadata' ->> 'github_username' = 'basanth-pedapati'
+);
+
+-- ---------------------------------------------------------------------------
+-- Helper view: latest score per developer
+-- Chirag's API route can query this instead of raw table for simplicity.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE VIEW developer_latest_scores AS
+SELECT DISTINCT ON (developer_id)
+    id,
+    developer_id,
+    score_version,
+    score_total,
+    merge_quality_score,
+    review_participation_score,
+    consistency_score,
+    pr_hygiene_score,
+    recent_activity_score,
+    metrics_json,
+    sufficient_data,
+    explanation,
+    computed_at
+FROM developer_scores
+ORDER BY developer_id, computed_at DESC;

--- a/lib/scoring/compute-developer-score.ts
+++ b/lib/scoring/compute-developer-score.ts
@@ -1,0 +1,158 @@
+import type { DeveloperMetrics, DeveloperScore, ScoreDimension } from "./scoring-types";
+import { SCORE_VERSION, SCORE_WEIGHTS } from "./scoring-types";
+import { checkSufficiency } from "./sufficiency-engine";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Clamp a value to [0, 1]. */
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}
+
+/** Build a ScoreDimension given a 0-1 raw ratio and its weight. */
+function dimension(raw: number, weight: number): ScoreDimension {
+  const clamped = clamp01(raw);
+  return {
+    raw: clamped,
+    score: Math.round(clamped * weight * 100),
+    weight,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-dimension scorers (each returns a 0-1 ratio)
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge Quality (30%)
+ * Rewards a high merge rate. Penalises prolific but rarely-merged contributors.
+ * Formula: merged_prs / total_prs
+ */
+function mergeQualityRatio(m: DeveloperMetrics): number {
+  if (m.total_prs === 0) return 0;
+  return m.merged_prs / m.total_prs;
+}
+
+/**
+ * Review Participation (20%)
+ * Rewards PRs that received a review — signals collaboration and visibility.
+ * Formula: prs_with_review_received / total_prs
+ */
+function reviewParticipationRatio(m: DeveloperMetrics): number {
+  if (m.total_prs === 0) return 0;
+  return m.prs_with_review_received / m.total_prs;
+}
+
+/**
+ * Consistency (20%)
+ * Rewards steady, spread-out contributions over the 90-day window.
+ * Max possible active_weeks in 90 days ≈ 13.
+ * Formula: active_weeks / 13
+ */
+function consistencyRatio(m: DeveloperMetrics): number {
+  const MAX_WEEKS = 13;
+  return m.active_weeks / MAX_WEEKS;
+}
+
+/**
+ * PR Hygiene (15%)
+ * Rewards clean PRs — tests touched, docs touched, no risky paths.
+ * Penalises rule violations (capped so it can't go below 0).
+ *
+ * Base score: 1.0
+ * +0.1 if tests_touched_rate >= 0.5
+ * +0.1 if docs_touched_rate >= 0.3
+ * -0.15 per rule violation per PR (capped at -1.0 total)
+ */
+function prHygieneRatio(m: DeveloperMetrics): number {
+  if (m.total_prs === 0) return 0;
+
+  let score = 0.8; // base
+
+  const tests_rate = m.prs_with_tests_touched / m.total_prs;
+  const docs_rate = m.prs_with_docs_touched / m.total_prs;
+  const violations_per_pr = m.total_rule_violations / m.total_prs;
+
+  if (tests_rate >= 0.5) score += 0.1;
+  if (docs_rate >= 0.3) score += 0.1;
+
+  // Each violation per PR deducts 0.15, capped so score floor is 0
+  const penalty = Math.min(violations_per_pr * 0.15, score);
+  score -= penalty;
+
+  return clamp01(score);
+}
+
+/**
+ * Recent Activity (15%)
+ * Rewards developers who contributed very recently.
+ * Decay curve: full score at 0 days, zero at 90 days.
+ * Formula: 1 - (days_since_last_pr / 90)
+ */
+function recentActivityRatio(m: DeveloperMetrics): number {
+  if (m.days_since_last_pr === null) return 0;
+  const MAX_DAYS = 90;
+  return 1 - Math.min(m.days_since_last_pr / MAX_DAYS, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes the Patch ID developer trust score (0-100) from aggregated metrics.
+ *
+ * Always returns a DeveloperScore — callers should check `sufficient_data`
+ * before displaying the score in the UI.
+ */
+export function computeDeveloperScore(metrics: DeveloperMetrics): DeveloperScore {
+  const { sufficient } = checkSufficiency(metrics);
+
+  const merge_quality = dimension(
+    mergeQualityRatio(metrics),
+    SCORE_WEIGHTS.merge_quality
+  );
+  const review_participation = dimension(
+    reviewParticipationRatio(metrics),
+    SCORE_WEIGHTS.review_participation
+  );
+  const consistency = dimension(
+    consistencyRatio(metrics),
+    SCORE_WEIGHTS.consistency
+  );
+  const pr_hygiene = dimension(
+    prHygieneRatio(metrics),
+    SCORE_WEIGHTS.pr_hygiene
+  );
+  const recent_activity = dimension(
+    recentActivityRatio(metrics),
+    SCORE_WEIGHTS.recent_activity
+  );
+
+  const score_total =
+    merge_quality.score +
+    review_participation.score +
+    consistency.score +
+    pr_hygiene.score +
+    recent_activity.score;
+
+  const explanation = sufficient
+    ? `Score ${score_total}/100 based on ${metrics.total_prs} PRs over the last ${metrics.window_days} days.`
+    : `Not enough data yet. Keep contributing to func(kode) to unlock your score.`;
+
+  return {
+    developer_id: metrics.developer_id,
+    score_version: SCORE_VERSION,
+    score_total: Math.min(100, score_total),
+    merge_quality,
+    review_participation,
+    consistency,
+    pr_hygiene,
+    recent_activity,
+    sufficient_data: sufficient,
+    explanation,
+    computed_at: new Date().toISOString(),
+  };
+}

--- a/lib/scoring/scoring-types.ts
+++ b/lib/scoring/scoring-types.ts
@@ -1,0 +1,93 @@
+/**
+ * Scoring types for Patch ID developer trust score.
+ *
+ * DeveloperMetrics   — raw aggregated numbers from pr_events (last 90 days)
+ * SufficiencyResult  — whether enough data exists to compute a meaningful score
+ * DeveloperScore     — final 0-100 score with per-dimension breakdown
+ */
+
+export interface DeveloperMetrics {
+  developer_id: string;
+
+  // window
+  window_days: number; // always 90 for v1
+
+  // PR counts
+  total_prs: number;
+  merged_prs: number;
+  closed_without_merge: number;
+
+  // review participation
+  prs_with_review_requested: number;
+  prs_with_review_received: number;
+
+  // code hygiene
+  total_rule_violations: number;
+  risky_paths_prs: number;
+  prs_with_tests_touched: number;
+  prs_with_docs_touched: number;
+
+  // churn metrics
+  avg_additions: number;
+  avg_deletions: number;
+  avg_changed_files: number;
+
+  // recency
+  days_since_last_pr: number | null; // null = never contributed
+
+  // consistency (spread of activity across weeks)
+  active_weeks: number; // distinct ISO weeks with at least 1 PR
+}
+
+export interface SufficiencyResult {
+  sufficient: boolean;
+  checks: {
+    min_prs: boolean;       // total_prs >= 3
+    has_merged: boolean;    // merged_prs >= 1
+    recency: boolean;       // days_since_last_pr <= 90
+  };
+  /** Human-readable explanation for the UI. */
+  reason: string | null;  // null when sufficient
+}
+
+export interface ScoreDimension {
+  raw: number;      // the intermediate value before weighting
+  score: number;    // 0-100 contribution from this dimension after weighting
+  weight: number;   // e.g. 0.30
+}
+
+export interface DeveloperScore {
+  developer_id: string;
+  score_version: number;        // increment when formula changes
+  score_total: number;          // 0-100, final trust score
+
+  // per-dimension breakdown
+  merge_quality: ScoreDimension;
+  review_participation: ScoreDimension;
+  consistency: ScoreDimension;
+  pr_hygiene: ScoreDimension;
+  recent_activity: ScoreDimension;
+
+  sufficient_data: boolean;
+  explanation: string;          // short human-readable summary
+  computed_at: string;          // ISO timestamp
+}
+
+/** Current formula version — bump when weights or thresholds change. */
+export const SCORE_VERSION = 1;
+
+/** Scoring weights — must sum to 1.0 */
+export const SCORE_WEIGHTS = {
+  merge_quality: 0.30,
+  review_participation: 0.20,
+  consistency: 0.20,
+  pr_hygiene: 0.15,
+  recent_activity: 0.15,
+} as const;
+
+/** Sufficiency thresholds */
+export const SUFFICIENCY_THRESHOLDS = {
+  min_total_prs: 3,
+  min_merged_prs: 1,
+  max_days_since_last_pr: 90,
+} as const;

--- a/lib/scoring/sufficiency-engine.ts
+++ b/lib/scoring/sufficiency-engine.ts
@@ -1,0 +1,62 @@
+import type { DeveloperMetrics, SufficiencyResult } from "./scoring-types";
+import { SUFFICIENCY_THRESHOLDS } from "./scoring-types";
+
+/**
+ * Determines whether a developer has enough contribution data to compute
+ * a meaningful trust score.
+ *
+ * v1 thresholds:
+ *   - at least 3 PRs in the last 90 days
+ *   - at least 1 merged PR
+ *   - last PR was within the last 90 days
+ *
+ * These thresholds are defined in SUFFICIENCY_THRESHOLDS and can be bumped
+ * by incrementing SCORE_VERSION in scoring-types.ts.
+ */
+export function checkSufficiency(metrics: DeveloperMetrics): SufficiencyResult {
+  const { min_total_prs, min_merged_prs, max_days_since_last_pr } =
+    SUFFICIENCY_THRESHOLDS;
+
+  const min_prs = metrics.total_prs >= min_total_prs;
+  const has_merged = metrics.merged_prs >= min_merged_prs;
+  const recency =
+    metrics.days_since_last_pr !== null &&
+    metrics.days_since_last_pr <= max_days_since_last_pr;
+
+  const sufficient = min_prs && has_merged && recency;
+
+  let reason: string | null = null;
+
+  if (!sufficient) {
+    const missing: string[] = [];
+
+    if (!min_prs) {
+      const remaining = min_total_prs - metrics.total_prs;
+      missing.push(
+        `${remaining} more PR${remaining > 1 ? "s" : ""} needed (minimum ${min_total_prs})`
+      );
+    }
+
+    if (!has_merged) {
+      missing.push("at least 1 merged PR required");
+    }
+
+    if (!recency) {
+      if (metrics.days_since_last_pr === null) {
+        missing.push("no PR activity found");
+      } else {
+        missing.push(
+          `last PR was ${metrics.days_since_last_pr} days ago — contribute within the last ${max_days_since_last_pr} days`
+        );
+      }
+    }
+
+    reason = missing.join("; ");
+  }
+
+  return {
+    sufficient,
+    checks: { min_prs, has_merged, recency },
+    reason,
+  };
+}


### PR DESCRIPTION
## Summary

This PR completes **Basanth's Sprint 4 tasks** — freezing and implementing the v1 scoring formula, sufficiency thresholds, TypeScript types, and the Supabase `developer_scores` table.

This is the **product + architecture layer** that Chirag's backend service and Prasanna's dashboard UI will build on top of.

---

## What's in this PR

### `lib/scoring/scoring-types.ts`
- `DeveloperMetrics` — raw aggregated numbers from `pr_events` over the last 90 days
- `SufficiencyResult` — result shape with per-check breakdown and a UI-ready reason string
- `DeveloperScore` — final 0–100 score with per-dimension breakdown
- `SCORE_WEIGHTS` — frozen v1 weights (must sum to 1.0)
- `SUFFICIENCY_THRESHOLDS` — v1 thresholds
- `SCORE_VERSION = 1` — bump this when formula changes

### `lib/scoring/sufficiency-engine.ts`
- `checkSufficiency(metrics)` — returns `SufficiencyResult`
- **v1 thresholds:**
  - `total_prs >= 3`
  - `merged_prs >= 1`
  - `days_since_last_pr <= 90`
- Returns a human-readable `reason` string for the UI when data is insufficient

### `lib/scoring/compute-developer-score.ts`
- `computeDeveloperScore(metrics)` — returns a full `DeveloperScore`
- **v1 weighted formula:**

| Dimension | Weight | Formula |
|---|---|---|
| Merge Quality | 30% | `merged_prs / total_prs` |
| Review Participation | 20% | `prs_with_review_received / total_prs` |
| Consistency | 20% | `active_weeks / 13` (13 weeks in 90 days) |
| PR Hygiene | 15% | base 0.8 + tests/docs bonus − violation penalty |
| Recent Activity | 15% | `1 − (days_since_last_pr / 90)` linear decay |

- Always returns a score — callers check `sufficient_data` before displaying
- Pure function, no DB calls, fully testable

### `database/developer_scores.sql`
- New `developer_scores` table with:
  - `score_total`, all 5 dimension scores, `metrics_json`, `sufficient_data`, `explanation`
  - `score_version` column for formula versioning
  - RLS: users read own scores, service role writes, admins read all
  - `developer_latest_scores` view — Chirag's API route can query this directly
  - Indexes on `developer_id`, `computed_at DESC`, `score_version`

---

## How to apply the DB migration

```bash
# paste contents of database/developer_scores.sql into Supabase SQL editor, or:
supabase db reset   # local — re-applies all sql files
```

---

## Dependencies for next tasks

- **Suyash** — the `DeveloperMetrics` type in `scoring-types.ts` is the exact shape your normalizer/aggregator should produce from `pr_events`. No changes needed from your side for the type contract.
- **Chirag** — import `computeDeveloperScore` from `lib/scoring/compute-developer-score.ts`. Query `developer_latest_scores` view from Supabase for the API route. Call `checkSufficiency` if you need the checks breakdown separately.
- **Prasanna** — `DeveloperScore.explanation` is a ready-to-render string. `SufficiencyResult.checks` gives you the 3 boolean checks for the checklist UI. `score_total` is the number to display.

---

## Checklist

- [x] Scoring types defined and exported
- [x] Sufficiency engine with v1 thresholds
- [x] Scoring formula with 5 weighted dimensions
- [x] DB migration with RLS + view
- [ ] Unit tests (to be added by Chirag or Basanth in follow-up)
- [ ] Integration with worker pipeline (Suyash's task)
- [ ] API route (Chirag's task)
- [ ] Dashboard UI (Prasanna's task)

---

**Reviewer:** @basanth-p
**Sprint:** Sprint 4 — Investor demo week