### PR TITLE
feat(github): enhance GitHub webhook processing and idempotency handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ GITHUB_WEBHOOK_SECRET=
 # Redis — BullMQ queue + idempotency store (Upstash rediss://... or local redis://localhost:6379)
 REDIS_URL=
 
+# Embedded BullMQ worker: auto-on in development; set true for Docker/standalone `next start`
+# Set false on Cloudflare/Vercel (processing uses post-response `after()` instead)
+ENABLE_PR_EVENTS_WORKER=
+
 # Version badge in navbar — auto-set from package.json at build time, no manual update needed
 # NEXT_PUBLIC_APP_VERSION=0.9.0
 

--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { buildPrEventJob, isSupportedWebhook } from "@/lib/github/build-pr-event-job";
+import { parseGitHubWebhookBody } from "@/lib/github/parse-webhook-body";
 import {
   claimIdempotencyKeys,
   releaseIdempotencyKeys,
 } from "@/lib/github/idempotency-store";
 import { enqueuePrEventJob } from "@/lib/queue/pr-events-queue";
+import { schedulePrEventProcessing } from "@/lib/queue/schedule-pr-event-processing";
 import { verifyGitHubWebhookSignature } from "@/lib/github/webhook-signature";
 import { isRedisConfigured } from "@/lib/redis/client";
 
@@ -14,8 +16,8 @@ export const runtime = "nodejs";
  * GitHub webhook — PR lifecycle events (open, sync, review, merge, close, edit).
  *
  * - HMAC validation via GITHUB_WEBHOOK_SECRET
- * - Idempotency via Redis (delivery_id + pr_id:sha:event_type)
- * - Jobs enqueued to BullMQ (Redis)
+ * - Idempotency: delivery_id + semantic key (see lib/github/idempotency-key.ts)
+ * - Jobs enqueued to BullMQ; processing runs via embedded worker (dev/Docker) or `after()` (serverless)
  *
  * Subscribe to: pull_request, pull_request_review
  * @see https://docs.github.com/en/webhooks/webhook-events-and-payloads
@@ -46,11 +48,18 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  if (githubEvent === "ping") {
+    return NextResponse.json({ ok: true, ping: true });
+  }
+
   let payload: Record<string, unknown>;
   try {
-    payload = JSON.parse(rawBody) as Record<string, unknown>;
+    payload = parseGitHubWebhookBody(
+      rawBody,
+      req.headers.get("content-type"),
+    );
   } catch {
-    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+    return NextResponse.json({ error: "Invalid webhook payload" }, { status: 400 });
   }
 
   const action = payload.action as string | undefined;
@@ -79,12 +88,14 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({
       ok: true,
       duplicate: true,
+      layer: idempotency.layer,
       idempotency_key: idempotency.key,
     });
   }
 
   try {
     const queueJobId = await enqueuePrEventJob(job);
+    schedulePrEventProcessing(job);
     return NextResponse.json({
       ok: true,
       queued: true,

--- a/instrumentation.pr-events-worker.ts
+++ b/instrumentation.pr-events-worker.ts
@@ -1,0 +1,9 @@
+import { startEmbeddedPrEventsWorker } from "@/lib/queue/pr-events-worker-runtime";
+
+export async function registerPrEventsWorker(): Promise<void> {
+  try {
+    await startEmbeddedPrEventsWorker();
+  } catch (error) {
+    console.error("[pr-events] failed to start embedded worker:", error);
+  }
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,8 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("./instrumentation.posthog-logs");
+    await import("./instrumentation.pr-events-worker").then((m) =>
+      m.registerPrEventsWorker(),
+    );
   }
 }

--- a/lib/github/build-pr-event-job.ts
+++ b/lib/github/build-pr-event-job.ts
@@ -1,6 +1,13 @@
 import { createClient } from "@supabase/supabase-js";
+import { buildSemanticIdempotencyKey } from "@/lib/github/idempotency-key";
 import { analyzeChangedPaths } from "@/lib/github/pr-path-analysis";
-import type { PrEventJob, PrEventType } from "@/lib/github/pr-event-types";
+import type { PrEventJob } from "@/lib/github/pr-event-types";
+import {
+  isSupportedPrWebhook,
+  resolvePrEventType,
+} from "@/lib/github/pr-event-support";
+
+export { isSupportedPrWebhook as isSupportedWebhook };
 
 type GitHubUser = { login?: string };
 type GitHubLabel = { name?: string };
@@ -94,54 +101,6 @@ async function resolveDeveloperId(githubUsername: string): Promise<string | null
   return data?.id ?? null;
 }
 
-export function mapPullRequestEventType(
-  action: string,
-  merged: boolean,
-): PrEventType | null {
-  switch (action) {
-    case "opened":
-    case "reopened":
-    case "ready_for_review":
-      return "opened";
-    case "synchronize":
-      return "synchronized";
-    case "edited":
-    case "labeled":
-    case "unlabeled":
-    case "review_requested":
-    case "review_request_removed":
-      return "edited";
-    case "closed":
-      return merged ? "merged" : "closed";
-    default:
-      return null;
-  }
-}
-
-export function buildIdempotencyKey(
-  githubPrId: number,
-  headSha: string,
-  eventType: PrEventType,
-  suffix?: string,
-): string {
-  const base = `${githubPrId}:${headSha}:${eventType}`;
-  return suffix ? `${base}:${suffix}` : base;
-}
-
-export function isSupportedWebhook(
-  githubEvent: string,
-  action: string | undefined,
-  merged?: boolean,
-): boolean {
-  if (githubEvent === "pull_request_review" && action === "submitted") {
-    return true;
-  }
-  if (githubEvent === "pull_request" && action) {
-    return mapPullRequestEventType(action, merged ?? false) !== null;
-  }
-  return false;
-}
-
 async function enrichFromGitHubApi(
   repoName: string,
   prNumber: number,
@@ -212,12 +171,11 @@ export async function buildPrEventJob(params: {
     return null;
   }
 
-  let eventType: PrEventType | null = null;
-  if (githubEvent === "pull_request_review" && action === "submitted") {
-    eventType = "reviewed";
-  } else if (githubEvent === "pull_request") {
-    eventType = mapPullRequestEventType(action, pr.merged ?? false);
-  }
+  let eventType = resolvePrEventType(
+    githubEvent,
+    action,
+    pr.merged ?? false,
+  );
 
   if (!eventType) {
     return null;
@@ -264,14 +222,13 @@ export async function buildPrEventJob(params: {
     updated_at: pr.updated_at,
     ingested_at: new Date().toISOString(),
     delivery_id: deliveryId,
-    idempotency_key: buildIdempotencyKey(
-      githubPrId,
+    idempotency_key: buildSemanticIdempotencyKey({
+      githubPtId: githubPrId,
       headSha,
       eventType,
-      githubEvent === "pull_request_review"
-        ? String(payload.review?.id ?? deliveryId)
-        : undefined,
-    ),
+      deliveryId,
+      reviewId: payload.review?.id,
+    }),
     github_event: githubEvent,
     github_action: action,
   };

--- a/lib/github/idempotency-key.ts
+++ b/lib/github/idempotency-key.ts
@@ -1,0 +1,55 @@
+import type { PrEventType } from "@/lib/github/pr-event-types";
+
+/**
+ * Idempotency strategy (two layers, both stored in Redis for 7 days):
+ *
+ * 1. **delivery:{X-GitHub-Delivery}**
+ *    Deduplicates exact GitHub webhook redeliveries of the same HTTP request.
+ *
+ * 2. **semantic:{semantic_key}**
+ *    Deduplicates logically identical PR events within the TTL window.
+ *
+ * Semantic key rules:
+ * | event_type   | semantic key |
+ * |--------------|--------------|
+ * | opened       | pr:{pt_id}:sha:{head_sha}:opened |
+ * | synchronized | pr:{pt_id}:sha:{head_sha}:synchronized |
+ * | merged       | pr:{pt_id}:sha:{head_sha}:merged |
+ * | closed       | pr:{pt_id}:sha:{head_sha}:closed |
+ * | reviewed     | pr:{pt_id}:review:{review_id} |
+ * | edited       | pr:{pt_id}:delivery:{delivery_id} |
+ *
+ * `edited` uses delivery_id because multiple label/edit events can share the same
+ * head SHA. `reviewed` uses review_id because one SHA can receive many reviews.
+ */
+export function buildSemanticIdempotencyKey(params: {
+  githubPtId: number;
+  headSha: string;
+  eventType: PrEventType;
+  deliveryId: string;
+  reviewId?: number;
+}): string {
+  const { githubPtId, headSha, eventType, deliveryId, reviewId } = params;
+
+  switch (eventType) {
+    case "reviewed":
+      return `pr:${githubPtId}:review:${reviewId ?? deliveryId}`;
+    case "edited":
+      return `pr:${githubPtId}:delivery:${deliveryId}`;
+    case "opened":
+    case "synchronized":
+    case "merged":
+    case "closed":
+      return `pr:${githubPtId}:sha:${headSha}:${eventType}`;
+    default:
+      return `pr:${githubPtId}:sha:${headSha}:${eventType}`;
+  }
+}
+
+export function deliveryIdempotencyKey(deliveryId: string): string {
+  return `delivery:${deliveryId}`;
+}
+
+export function semanticIdempotencyRedisKey(semanticKey: string): string {
+  return `semantic:${semanticKey}`;
+}

--- a/lib/github/idempotency-store.ts
+++ b/lib/github/idempotency-store.ts
@@ -1,56 +1,68 @@
 import { getRedisConnection } from "@/lib/redis/client";
+import {
+  deliveryIdempotencyKey,
+  semanticIdempotencyRedisKey,
+} from "@/lib/github/idempotency-key";
 import { IDEMPOTENCY_TTL_SECONDS } from "@/lib/github/pr-event-types";
 
 const KEY_PREFIX = "webhook:idempotency:";
 
 export type IdempotencyResult =
   | { status: "new" }
-  | { status: "duplicate"; key: string };
+  | { status: "duplicate"; layer: "delivery" | "semantic"; key: string };
 
 /**
- * Returns "new" if this delivery has not been processed.
- * Uses delivery_id (X-GitHub-Delivery) and a composite pr_id+sha key.
+ * Atomically claims delivery + semantic idempotency keys.
+ * Both must succeed; rolls back delivery key if semantic key is taken.
  */
 export async function claimIdempotencyKeys(
   deliveryId: string,
-  compositeKey: string,
+  semanticKey: string,
 ): Promise<IdempotencyResult> {
   const redis = getRedisConnection();
   await redis.connect().catch(() => {
     /* already connected */
   });
 
-  const deliveryRedisKey = `${KEY_PREFIX}delivery:${deliveryId}`;
-  const compositeRedisKey = `${KEY_PREFIX}composite:${compositeKey}`;
+  const deliveryRedisKey = `${KEY_PREFIX}${deliveryIdempotencyKey(deliveryId)}`;
+  const semanticRedisKey = `${KEY_PREFIX}${semanticIdempotencyRedisKey(semanticKey)}`;
 
   const pipeline = redis.multi();
   pipeline.set(deliveryRedisKey, "1", "EX", IDEMPOTENCY_TTL_SECONDS, "NX");
-  pipeline.set(compositeRedisKey, deliveryId, "EX", IDEMPOTENCY_TTL_SECONDS, "NX");
+  pipeline.set(semanticRedisKey, deliveryId, "EX", IDEMPOTENCY_TTL_SECONDS, "NX");
 
   const results = await pipeline.exec();
   const deliverySet = results?.[0]?.[1] === "OK";
-  const compositeSet = results?.[1]?.[1] === "OK";
+  const semanticSet = results?.[1]?.[1] === "OK";
 
   if (!deliverySet) {
-    return { status: "duplicate", key: deliveryId };
+    return {
+      status: "duplicate",
+      layer: "delivery",
+      key: deliveryIdempotencyKey(deliveryId),
+    };
   }
 
-  if (!compositeSet) {
+  if (!semanticSet) {
     await redis.del(deliveryRedisKey);
-    return { status: "duplicate", key: compositeKey };
+    return {
+      status: "duplicate",
+      layer: "semantic",
+      key: semanticKey,
+    };
   }
 
   return { status: "new" };
 }
 
-/** Release keys on enqueue failure so GitHub can retry. */
+/** Release keys when enqueue fails so GitHub can retry the delivery. */
 export async function releaseIdempotencyKeys(
   deliveryId: string,
-  compositeKey: string,
+  semanticKey: string,
 ): Promise<void> {
   const redis = getRedisConnection();
   await redis.del(
-    `${KEY_PREFIX}delivery:${deliveryId}`,
-    `${KEY_PREFIX}composite:${compositeKey}`,
+    `${KEY_PREFIX}${deliveryIdempotencyKey(deliveryId)}`,
+    `${KEY_PREFIX}${semanticIdempotencyRedisKey(semanticKey)}`,
   );
 }

--- a/lib/github/parse-webhook-body.ts
+++ b/lib/github/parse-webhook-body.ts
@@ -1,0 +1,21 @@
+/**
+ * Parse GitHub webhook body — supports JSON and x-www-form-urlencoded (payload=...).
+ * @see https://docs.github.com/en/webhooks/using-webhooks/securing-your-webhooks
+ */
+export function parseGitHubWebhookBody(
+  rawBody: string,
+  contentType: string | null,
+): Record<string, unknown> {
+  const type = contentType?.toLowerCase() ?? "";
+
+  if (type.includes("application/x-www-form-urlencoded")) {
+    const params = new URLSearchParams(rawBody);
+    const payload = params.get("payload");
+    if (!payload) {
+      throw new Error("Missing payload field in form-encoded body");
+    }
+    return JSON.parse(payload) as Record<string, unknown>;
+  }
+
+  return JSON.parse(rawBody) as Record<string, unknown>;
+}

--- a/lib/github/pr-event-support.ts
+++ b/lib/github/pr-event-support.ts
@@ -1,0 +1,70 @@
+import type { PrEventType } from "@/lib/github/pr-event-types";
+
+/** GitHub webhook events we subscribe to for PR lifecycle tracking. */
+export const PR_WEBHOOK_EVENTS = ["pull_request", "pull_request_review"] as const;
+
+export type PrWebhookEvent = (typeof PR_WEBHOOK_EVENTS)[number];
+
+/**
+ * pull_request actions → internal event_type.
+ * @see https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request
+ */
+export const PULL_REQUEST_ACTION_MAP: Record<string, PrEventType | null> = {
+  opened: "opened",
+  reopened: "opened",
+  ready_for_review: "opened",
+  synchronize: "synchronized",
+  edited: "edited",
+  labeled: "edited",
+  unlabeled: "edited",
+  review_requested: "edited",
+  review_request_removed: "edited",
+  closed: null, // resolved via merged flag → merged | closed
+};
+
+/** pull_request_review actions we handle. */
+export const PULL_REQUEST_REVIEW_ACTIONS = ["submitted"] as const;
+
+export function resolvePullRequestEventType(
+  action: string,
+  merged: boolean,
+): PrEventType | null {
+  if (action === "closed") {
+    return merged ? "merged" : "closed";
+  }
+  return PULL_REQUEST_ACTION_MAP[action] ?? null;
+}
+
+export function isSupportedPrWebhook(
+  githubEvent: string,
+  action: string | undefined,
+  merged?: boolean,
+): boolean {
+  if (!action) {
+    return false;
+  }
+
+  if (githubEvent === "pull_request_review") {
+    return (PULL_REQUEST_REVIEW_ACTIONS as readonly string[]).includes(action);
+  }
+
+  if (githubEvent === "pull_request") {
+    return resolvePullRequestEventType(action, merged ?? false) !== null;
+  }
+
+  return false;
+}
+
+export function resolvePrEventType(
+  githubEvent: string,
+  action: string,
+  merged: boolean,
+): PrEventType | null {
+  if (githubEvent === "pull_request_review" && action === "submitted") {
+    return "reviewed";
+  }
+  if (githubEvent === "pull_request") {
+    return resolvePullRequestEventType(action, merged);
+  }
+  return null;
+}

--- a/lib/github/pr-event-types.ts
+++ b/lib/github/pr-event-types.ts
@@ -39,7 +39,7 @@ export type PrEventJob = {
   ingested_at: string;
   /** X-GitHub-Delivery — used for idempotency */
   delivery_id: string;
-  /** Composite key: {github_pr_id}:{head_sha}:{event_type} */
+  /** Semantic idempotency key — see lib/github/idempotency-key.ts */
   idempotency_key: string;
   github_event: string;
   github_action: string;

--- a/lib/github/test/webhook.test.ts
+++ b/lib/github/test/webhook.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { createHmac } from "crypto";
+import {
+  buildSemanticIdempotencyKey,
+  deliveryIdempotencyKey,
+} from "@/lib/github/idempotency-key";
+import {
+  isSupportedPrWebhook,
+  resolvePrEventType,
+  resolvePullRequestEventType,
+} from "@/lib/github/pr-event-support";
+import { analyzeChangedPaths } from "@/lib/github/pr-path-analysis";
+import { parseGitHubWebhookBody } from "@/lib/github/parse-webhook-body";
+import { verifyGitHubWebhookSignature } from "@/lib/github/webhook-signature";
+import {
+  shouldMoveToDeadLetterQueue,
+} from "@/lib/queue/move-to-dlq";
+import { DEFAULT_JOB_ATTEMPTS } from "@/lib/queue/pr-events-dlq-types";
+
+function signBody(body: string, secret: string): Headers {
+  const digest = createHmac("sha256", secret).update(body, "utf8").digest("hex");
+  return new Headers({ "x-hub-signature-256": `sha256=${digest}` });
+}
+
+describe("verifyGitHubWebhookSignature", () => {
+  it("accepts valid SHA-256 signatures", () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret";
+    const body = '{"action":"opened"}';
+    expect(verifyGitHubWebhookSignature(body, signBody(body, "test-secret"))).toEqual({
+      valid: true,
+    });
+  });
+
+  it("rejects invalid signatures", () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret";
+    const body = '{"action":"opened"}';
+    const result = verifyGitHubWebhookSignature(
+      body,
+      new Headers({ "x-hub-signature-256": "sha256=deadbeef" }),
+    );
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("PR event support", () => {
+  it("supports pull_request lifecycle actions", () => {
+    expect(isSupportedPrWebhook("pull_request", "opened")).toBe(true);
+    expect(isSupportedPrWebhook("pull_request", "synchronize")).toBe(true);
+    expect(isSupportedPrWebhook("pull_request", "labeled")).toBe(true);
+    expect(isSupportedPrWebhook("pull_request", "closed", false)).toBe(true);
+    expect(isSupportedPrWebhook("pull_request", "closed", true)).toBe(true);
+    expect(isSupportedPrWebhook("pull_request_review", "submitted")).toBe(true);
+    expect(isSupportedPrWebhook("push", "created")).toBe(false);
+    expect(isSupportedPrWebhook("pull_request", "assigned")).toBe(false);
+  });
+
+  it("maps actions to internal event types", () => {
+    expect(resolvePullRequestEventType("opened", false)).toBe("opened");
+    expect(resolvePullRequestEventType("synchronize", false)).toBe("synchronized");
+    expect(resolvePullRequestEventType("labeled", false)).toBe("edited");
+    expect(resolvePullRequestEventType("closed", true)).toBe("merged");
+    expect(resolvePullRequestEventType("closed", false)).toBe("closed");
+    expect(resolvePrEventType("pull_request_review", "submitted", false)).toBe(
+      "reviewed",
+    );
+  });
+});
+
+describe("idempotency keys", () => {
+  it("uses sha-based keys for sync and lifecycle events", () => {
+    expect(
+      buildSemanticIdempotencyKey({
+        githubPtId: 99,
+        headSha: "abc",
+        eventType: "synchronized",
+        deliveryId: "del-1",
+      }),
+    ).toBe("pr:99:sha:abc:synchronized");
+
+    expect(
+      buildSemanticIdempotencyKey({
+        githubPtId: 99,
+        headSha: "abc",
+        eventType: "merged",
+        deliveryId: "del-2",
+      }),
+    ).toBe("pr:99:sha:abc:merged");
+  });
+
+  it("uses review id for reviewed events", () => {
+    expect(
+      buildSemanticIdempotencyKey({
+        githubPtId: 99,
+        headSha: "abc",
+        eventType: "reviewed",
+        deliveryId: "del-3",
+        reviewId: 555,
+      }),
+    ).toBe("pr:99:review:555");
+  });
+
+  it("uses delivery id for edited events (multiple per sha)", () => {
+    expect(
+      buildSemanticIdempotencyKey({
+        githubPtId: 99,
+        headSha: "abc",
+        eventType: "edited",
+        deliveryId: "del-4",
+      }),
+    ).toBe("pr:99:delivery:del-4");
+  });
+
+  it("formats delivery layer keys", () => {
+    expect(deliveryIdempotencyKey("72d3162e-cc78-11e3-81ab-4c9367dc0958")).toBe(
+      "delivery:72d3162e-cc78-11e3-81ab-4c9367dc0958",
+    );
+  });
+});
+
+describe("dead letter queue", () => {
+  it("moves to DLQ only after max attempts", () => {
+    const job = {
+      attemptsMade: DEFAULT_JOB_ATTEMPTS,
+      opts: { attempts: DEFAULT_JOB_ATTEMPTS },
+    };
+    expect(shouldMoveToDeadLetterQueue(job as never)).toBe(true);
+
+    const retrying = {
+      attemptsMade: 2,
+      opts: { attempts: DEFAULT_JOB_ATTEMPTS },
+    };
+    expect(shouldMoveToDeadLetterQueue(retrying as never)).toBe(false);
+  });
+});
+
+describe("parseGitHubWebhookBody", () => {
+  it("parses JSON bodies", () => {
+    const body = JSON.stringify({ action: "opened" });
+    expect(parseGitHubWebhookBody(body, "application/json")).toEqual({
+      action: "opened",
+    });
+  });
+
+  it("parses form-urlencoded bodies", () => {
+    const json = JSON.stringify({ zen: "Accessible for all." });
+    const body = `payload=${encodeURIComponent(json)}`;
+    expect(
+      parseGitHubWebhookBody(body, "application/x-www-form-urlencoded"),
+    ).toEqual({ zen: "Accessible for all." });
+  });
+});
+
+describe("analyzeChangedPaths", () => {
+  it("flags tests, docs, and risky paths", () => {
+    const result = analyzeChangedPaths([
+      "lib/auth/login.ts",
+      "docs/api/webhook.md",
+      "tests/webhook.test.ts",
+      ".env.example",
+    ]);
+    expect(result.tests_touched).toBe(true);
+    expect(result.docs_touched).toBe(true);
+    expect(result.risky_paths_hit).toBe(true);
+  });
+});

--- a/lib/queue/create-pr-events-worker.ts
+++ b/lib/queue/create-pr-events-worker.ts
@@ -1,0 +1,64 @@
+import { Worker, type Job } from "bullmq";
+import { getRedisConnectionOptions } from "@/lib/redis/client";
+import {
+  PR_EVENTS_QUEUE_NAME,
+  type PrEventJob,
+} from "@/lib/github/pr-event-types";
+import {
+  moveToDeadLetterQueue,
+  shouldMoveToDeadLetterQueue,
+} from "@/lib/queue/move-to-dlq";
+import { processPrEventJob } from "@/lib/queue/process-pr-event-job";
+import {
+  DEFAULT_JOB_ATTEMPTS,
+  DEFAULT_JOB_BACKOFF_MS,
+} from "@/lib/queue/pr-events-dlq-types";
+
+export type PrEventsWorkerOptions = {
+  concurrency?: number;
+};
+
+/**
+ * BullMQ worker for the PR events queue.
+ * On exhausted retries, jobs are moved to the `pr-events-dlq` dead-letter queue.
+ */
+export function createPrEventsWorker(
+  options: PrEventsWorkerOptions = {},
+): Worker<PrEventJob> {
+  const worker = new Worker<PrEventJob>(
+    PR_EVENTS_QUEUE_NAME,
+    async (job) => {
+      await processPrEventJob(job.data);
+    },
+    {
+      connection: getRedisConnectionOptions(),
+      concurrency: options.concurrency ?? 5,
+    },
+  );
+
+  worker.on("failed", async (job: Job<PrEventJob> | undefined, error: Error) => {
+    if (!job || !shouldMoveToDeadLetterQueue(job)) {
+      return;
+    }
+
+    try {
+      const dlqJobId = await moveToDeadLetterQueue(job, error);
+      console.error(
+        `[pr-events] moved to DLQ after ${job.attemptsMade} attempts`,
+        { dlq_job_id: dlqJobId, delivery_id: job.data.delivery_id, error: error.message },
+      );
+    } catch (dlqError) {
+      console.error("[pr-events] failed to move job to DLQ:", dlqError);
+    }
+  });
+
+  worker.on("completed", (job) => {
+    console.log(
+      `[pr-events] processed ${job.data.event_type} PR #${job.data.pr_number} (${job.data.delivery_id})`,
+    );
+  });
+
+  return worker;
+}
+
+export { DEFAULT_JOB_ATTEMPTS, DEFAULT_JOB_BACKOFF_MS };

--- a/lib/queue/fulfill-pr-event-job.ts
+++ b/lib/queue/fulfill-pr-event-job.ts
@@ -1,0 +1,69 @@
+import type { PrEventJob } from "@/lib/github/pr-event-types";
+import { PR_EVENTS_QUEUE_NAME } from "@/lib/github/pr-event-types";
+import { enqueueDeadLetterJob } from "@/lib/queue/pr-events-dlq";
+import {
+  DEFAULT_JOB_ATTEMPTS,
+  DEFAULT_JOB_BACKOFF_MS,
+} from "@/lib/queue/pr-events-dlq-types";
+import { processPrEventJob } from "@/lib/queue/process-pr-event-job";
+import { getPrEventsQueue } from "@/lib/queue/pr-events-queue";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function removeQueueJob(deliveryId: string): Promise<void> {
+  const queue = getPrEventsQueue();
+  const bullJob = await queue.getJob(deliveryId);
+  if (bullJob) {
+    await bullJob.remove();
+  }
+}
+
+/**
+ * Process a PR event job with retries, then remove from the main queue or move to DLQ.
+ * Used by post-response `after()` processing on serverless and as a fast path when embedded worker is off.
+ */
+export async function fulfillPrEventJob(job: PrEventJob): Promise<void> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= DEFAULT_JOB_ATTEMPTS; attempt++) {
+    try {
+      await processPrEventJob(job);
+      await removeQueueJob(job.delivery_id);
+      console.log(
+        `[pr-events] fulfilled ${job.event_type} PR #${job.pr_number} (${job.delivery_id})`,
+      );
+      return;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.warn(
+        `[pr-events] fulfill attempt ${attempt}/${DEFAULT_JOB_ATTEMPTS} failed:`,
+        lastError.message,
+      );
+
+      if (attempt < DEFAULT_JOB_ATTEMPTS) {
+        await sleep(DEFAULT_JOB_BACKOFF_MS * 2 ** (attempt - 1));
+      }
+    }
+  }
+
+  const error = lastError ?? new Error("Unknown processing error");
+
+  await enqueueDeadLetterJob({
+    original_job: job,
+    failed_at: new Date().toISOString(),
+    error_message: error.message,
+    error_stack: error.stack ?? null,
+    attempts_made: DEFAULT_JOB_ATTEMPTS,
+    bull_job_id: job.delivery_id,
+    source_queue: PR_EVENTS_QUEUE_NAME,
+  });
+
+  await removeQueueJob(job.delivery_id);
+
+  console.error(
+    `[pr-events] moved to DLQ after inline retries (${job.delivery_id}):`,
+    error.message,
+  );
+}

--- a/lib/queue/move-to-dlq.ts
+++ b/lib/queue/move-to-dlq.ts
@@ -1,0 +1,32 @@
+import type { Job } from "bullmq";
+import type { PrEventJob } from "@/lib/github/pr-event-types";
+import { PR_EVENTS_QUEUE_NAME } from "@/lib/github/pr-event-types";
+import { enqueueDeadLetterJob } from "@/lib/queue/pr-events-dlq";
+import {
+  DEFAULT_JOB_ATTEMPTS,
+  type PrEventDlqJob,
+} from "@/lib/queue/pr-events-dlq-types";
+
+export function shouldMoveToDeadLetterQueue(
+  job: Job<PrEventJob>,
+): boolean {
+  const maxAttempts = job.opts.attempts ?? DEFAULT_JOB_ATTEMPTS;
+  return job.attemptsMade >= maxAttempts;
+}
+
+export async function moveToDeadLetterQueue(
+  job: Job<PrEventJob>,
+  error: Error,
+): Promise<string> {
+  const dlqPayload: PrEventDlqJob = {
+    original_job: job.data,
+    failed_at: new Date().toISOString(),
+    error_message: error.message,
+    error_stack: error.stack ?? null,
+    attempts_made: job.attemptsMade,
+    bull_job_id: job.id ?? null,
+    source_queue: PR_EVENTS_QUEUE_NAME,
+  };
+
+  return enqueueDeadLetterJob(dlqPayload);
+}

--- a/lib/queue/pr-events-dlq-types.ts
+++ b/lib/queue/pr-events-dlq-types.ts
@@ -1,0 +1,20 @@
+import {
+  PR_EVENTS_QUEUE_NAME,
+  type PrEventJob,
+} from "@/lib/github/pr-event-types";
+
+/** Dead-letter queue for PR event jobs that exhaust retries. */
+export const PR_EVENTS_DLQ_NAME = "pr-events-dlq";
+
+export type PrEventDlqJob = {
+  original_job: PrEventJob;
+  failed_at: string;
+  error_message: string;
+  error_stack: string | null;
+  attempts_made: number;
+  bull_job_id: string | null;
+  source_queue: typeof PR_EVENTS_QUEUE_NAME;
+};
+
+export const DEFAULT_JOB_ATTEMPTS = 5;
+export const DEFAULT_JOB_BACKOFF_MS = 2000;

--- a/lib/queue/pr-events-dlq.ts
+++ b/lib/queue/pr-events-dlq.ts
@@ -1,0 +1,38 @@
+import { Queue } from "bullmq";
+import { getRedisConnectionOptions } from "@/lib/redis/client";
+import {
+  PR_EVENTS_DLQ_NAME,
+  type PrEventDlqJob,
+} from "@/lib/queue/pr-events-dlq-types";
+
+let dlq: Queue<PrEventDlqJob> | null = null;
+
+export function getPrEventsDlq(): Queue<PrEventDlqJob> {
+  if (!dlq) {
+    dlq = new Queue<PrEventDlqJob>(PR_EVENTS_DLQ_NAME, {
+      connection: getRedisConnectionOptions(),
+      defaultJobOptions: {
+        removeOnComplete: { count: 5000 },
+        removeOnFail: { count: 10000 },
+      },
+    });
+  }
+  return dlq;
+}
+
+export async function enqueueDeadLetterJob(
+  dlqJob: PrEventDlqJob,
+): Promise<string> {
+  const queue = getPrEventsDlq();
+  const job = await queue.add("dead-letter", dlqJob, {
+    jobId: `dlq:${dlqJob.original_job.delivery_id}`,
+  });
+  return job.id ?? dlqJob.original_job.delivery_id;
+}
+
+export async function closePrEventsDlq(): Promise<void> {
+  if (dlq) {
+    await dlq.close();
+    dlq = null;
+  }
+}

--- a/lib/queue/pr-events-queue.ts
+++ b/lib/queue/pr-events-queue.ts
@@ -4,6 +4,10 @@ import {
   PR_EVENTS_QUEUE_NAME,
   type PrEventJob,
 } from "@/lib/github/pr-event-types";
+import {
+  DEFAULT_JOB_ATTEMPTS,
+  DEFAULT_JOB_BACKOFF_MS,
+} from "@/lib/queue/pr-events-dlq-types";
 
 let prEventsQueue: Queue<PrEventJob> | null = null;
 
@@ -12,10 +16,10 @@ export function getPrEventsQueue(): Queue<PrEventJob> {
     prEventsQueue = new Queue<PrEventJob>(PR_EVENTS_QUEUE_NAME, {
       connection: getRedisConnectionOptions(),
       defaultJobOptions: {
-        attempts: 5,
-        backoff: { type: "exponential", delay: 2000 },
+        attempts: DEFAULT_JOB_ATTEMPTS,
+        backoff: { type: "exponential", delay: DEFAULT_JOB_BACKOFF_MS },
         removeOnComplete: { count: 1000 },
-        removeOnFail: { count: 5000 },
+        removeOnFail: false,
       },
     });
   }

--- a/lib/queue/pr-events-worker-runtime.ts
+++ b/lib/queue/pr-events-worker-runtime.ts
@@ -1,0 +1,69 @@
+import type { Worker } from "bullmq";
+import { createPrEventsWorker } from "@/lib/queue/create-pr-events-worker";
+import { isRedisConfigured } from "@/lib/redis/client";
+
+type WorkerGlobal = typeof globalThis & {
+  __prEventsWorker?: Worker;
+  __prEventsWorkerStarting?: Promise<Worker>;
+};
+
+const workerGlobal = globalThis as WorkerGlobal;
+
+/**
+ * Embedded BullMQ worker can only run on long-lived Node processes (next dev, next start, Docker).
+ * Serverless (Cloudflare/Vercel) uses post-response processing via `after()` instead.
+ */
+export function canRunEmbeddedPrEventsWorker(): boolean {
+  if (process.env.ENABLE_PR_EVENTS_WORKER === "false") {
+    return false;
+  }
+  if (!isRedisConfigured()) {
+    return false;
+  }
+  if (process.env.NEXT_RUNTIME !== "nodejs") {
+    return false;
+  }
+  if (process.env.ENABLE_PR_EVENTS_WORKER === "true") {
+    return true;
+  }
+  if (process.env.NODE_ENV === "development") {
+    return true;
+  }
+  if (process.env.VERCEL === "1" || process.env.AWS_LAMBDA_FUNCTION_NAME) {
+    return false;
+  }
+  return false;
+}
+
+/** Start the embedded worker once per Node process (survives Next.js hot reload). */
+export async function startEmbeddedPrEventsWorker(): Promise<Worker | null> {
+  if (!canRunEmbeddedPrEventsWorker()) {
+    return null;
+  }
+
+  if (workerGlobal.__prEventsWorker) {
+    return workerGlobal.__prEventsWorker;
+  }
+
+  if (!workerGlobal.__prEventsWorkerStarting) {
+    workerGlobal.__prEventsWorkerStarting = (async () => {
+      const worker = createPrEventsWorker();
+      workerGlobal.__prEventsWorker = worker;
+      console.log("[pr-events] embedded worker started");
+      return worker;
+    })();
+  }
+
+  return workerGlobal.__prEventsWorkerStarting;
+}
+
+export async function stopEmbeddedPrEventsWorker(): Promise<void> {
+  const worker = workerGlobal.__prEventsWorker;
+  if (!worker) {
+    return;
+  }
+  await worker.close();
+  workerGlobal.__prEventsWorker = undefined;
+  workerGlobal.__prEventsWorkerStarting = undefined;
+  console.log("[pr-events] embedded worker stopped");
+}

--- a/lib/queue/process-pr-event-job.ts
+++ b/lib/queue/process-pr-event-job.ts
@@ -1,0 +1,68 @@
+import { createClient } from "@supabase/supabase-js";
+import type { PrEventJob } from "@/lib/github/pr-event-types";
+
+export class PrEventProcessingError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "PrEventProcessingError";
+  }
+}
+
+/**
+ * Persists a PR event job to Supabase `pr_events`.
+ * Throws on failure so BullMQ can retry / dead-letter the job.
+ */
+export async function processPrEventJob(job: PrEventJob): Promise<void> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceKey) {
+    throw new PrEventProcessingError(
+      "SUPABASE_SERVICE_ROLE_KEY is required to process PR event jobs",
+    );
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey);
+
+  const row = {
+    id: job.id,
+    developer_id: job.developer_id,
+    repo_name: job.repo_name,
+    pr_number: job.pr_number,
+    github_pt_id: job.github_pt_id,
+    event_type: job.event_type,
+    title: job.title,
+    body: job.body,
+    author_username: job.author_username,
+    base_branch: job.base_branch,
+    head_branch: job.head_branch,
+    additions: job.additions,
+    deletions: job.deletions,
+    changed_files: job.changed_files,
+    commits_count: job.commits_count,
+    review_count: job.review_count,
+    requested_reviewers_count: job.requested_reviewers_count,
+    labels_json: job.labels_json ? JSON.parse(job.labels_json) : null,
+    tests_touched: job.tests_touched,
+    docs_touched: job.docs_touched,
+    risky_paths_hit: job.risky_paths_hit,
+    state: job.state,
+    merged_at: job.merged_at,
+    created_at: job.created_at,
+    updated_at: job.updated_at,
+    ingested_at: job.ingested_at,
+    delivery_id: job.delivery_id,
+    idempotency_key: job.idempotency_key,
+  };
+
+  const { error } = await supabase.from("pr_events").upsert(row, {
+    onConflict: "delivery_id",
+    ignoreDuplicates: false,
+  });
+
+  if (error) {
+    throw new PrEventProcessingError(`Failed to persist pr_event: ${error.message}`, {
+      cause: error,
+    });
+  }
+}

--- a/lib/queue/schedule-pr-event-processing.ts
+++ b/lib/queue/schedule-pr-event-processing.ts
@@ -1,0 +1,24 @@
+import { after } from "next/server";
+import type { PrEventJob } from "@/lib/github/pr-event-types";
+import { fulfillPrEventJob } from "@/lib/queue/fulfill-pr-event-job";
+import { canRunEmbeddedPrEventsWorker } from "@/lib/queue/pr-events-worker-runtime";
+
+/**
+ * Schedules PR event processing after the webhook response is sent.
+ *
+ * - Serverless (Cloudflare/Vercel): primary processor via `fulfillPrEventJob`
+ * - Long-lived Node with embedded worker: worker consumes the queue (no inline fulfill)
+ */
+export function schedulePrEventProcessing(job: PrEventJob): void {
+  if (canRunEmbeddedPrEventsWorker()) {
+    return;
+  }
+
+  after(async () => {
+    try {
+      await fulfillPrEventJob(job);
+    } catch (error) {
+      console.error("[pr-events] scheduled processing failed:", error);
+    }
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@radix-ui/react-label": "^2.1.6",
         "@radix-ui/react-slot": "^1.2.2",
         "@supabase/auth-helpers-nextjs": "^0.10.0",
-        "@supabase/ssr": "*",
+        "@supabase/ssr": "latest",
         "@supabase/supabase-js": "^2.106.2",
         "bullmq": "^5.79.0",
         "chart.js": "^4.5.0",
@@ -28,7 +28,7 @@
         "ioredis": "^5.11.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.511.0",
-        "next": "*",
+        "next": "latest",
         "next-themes": "^0.4.6",
         "posthog-js": "^1.379.0",
         "posthog-node": "^5.36.17",
@@ -54,6 +54,7 @@
         "postcss": "8.5.15",
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
+        "tsx": "^4.22.4",
         "typescript": "^5",
         "vitest": "^4.1.7",
         "wrangler": "^4.103.0"
@@ -13674,6 +13675,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
-    "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
+    "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
+    "worker:pr-events": "tsx workers/process-pr-events.ts",
+    "test:webhook": "node scripts/test/test-github-webhook.mjs"
   },
   "dependencies": {
     "@opentelemetry/api-logs": "0.218.0",
@@ -64,6 +66,7 @@
     "postcss": "8.5.15",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
+    "tsx": "^4.22.4",
     "typescript": "^5",
     "vitest": "^4.1.7",
     "wrangler": "^4.103.0"

--- a/scripts/test/test-github-webhook.mjs
+++ b/scripts/test/test-github-webhook.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Send a signed test request to /api/github/webhook.
+ *
+ * Usage:
+ *   node scripts/test-github-webhook.mjs                    # ping → localhost:3000
+ *   node scripts/test-github-webhook.mjs ping               # ping
+ *   node scripts/test-github-webhook.mjs pr                 # pull_request opened
+ *   node scripts/test-github-webhook.mjs pr https://xxx.ngrok-free.app
+ *
+ * Reads GITHUB_WEBHOOK_SECRET from .env.local (or process.env).
+ */
+import { createHmac, randomUUID } from "crypto";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+function loadEnvLocal() {
+  try {
+    const raw = readFileSync(resolve(process.cwd(), ".env.local"), "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1) continue;
+      const key = trimmed.slice(0, eq).trim();
+      let value = trimmed.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!process.env[key]) process.env[key] = value;
+    }
+  } catch {
+    /* .env.local optional if env vars already set */
+  }
+}
+
+function sign(body, secret) {
+  const digest = createHmac("sha256", secret).update(body, "utf8").digest("hex");
+  return `sha256=${digest}`;
+}
+
+const PING_PAYLOAD = {
+  zen: "Manual curl test.",
+  hook_id: 1,
+  repository: { full_name: "patchid/func-kode" },
+};
+
+const PR_OPENED_PAYLOAD = {
+  action: "opened",
+  number: 1,
+  pull_request: {
+    id: 999001,
+    number: 1,
+    title: "Manual webhook test",
+    body: "Triggered via scripts/test-github-webhook.mjs",
+    state: "open",
+    merged: false,
+    merged_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    user: { login: "test-user" },
+    base: { ref: "main", sha: "base000" },
+    head: { ref: "feature/test-webhook", sha: "head000abc123" },
+    labels: [],
+    requested_reviewers: [],
+  },
+  repository: { full_name: "patchid/func-kode" },
+  sender: { login: "test-user" },
+};
+
+loadEnvLocal();
+
+const secret = process.env.GITHUB_WEBHOOK_SECRET?.trim();
+if (!secret) {
+  console.error("GITHUB_WEBHOOK_SECRET is not set (.env.local or env)");
+  process.exit(1);
+}
+
+const mode = (process.argv[2] ?? "ping").toLowerCase();
+const baseUrl = (process.argv[3] ?? "http://localhost:3000").replace(/\/$/, "");
+const url = `${baseUrl}/api/github/webhook`;
+
+const isPing = mode === "ping";
+const githubEvent = isPing ? "ping" : "pull_request";
+const payload = isPing ? PING_PAYLOAD : PR_OPENED_PAYLOAD;
+const body = JSON.stringify(payload);
+const deliveryId = randomUUID();
+const signature = sign(body, secret);
+
+console.log(`POST ${url}`);
+console.log(`X-GitHub-Event: ${githubEvent}`);
+console.log(`X-GitHub-Delivery: ${deliveryId}`);
+console.log("");
+
+const res = await fetch(url, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "X-GitHub-Event": githubEvent,
+    "X-GitHub-Delivery": deliveryId,
+    "X-Hub-Signature-256": signature,
+    "User-Agent": "GitHub-Hookshot/manual-test",
+  },
+  body,
+});
+
+const text = await res.text();
+console.log(`Status: ${res.status}`);
+try {
+  console.log(JSON.stringify(JSON.parse(text), null, 2));
+} catch {
+  console.log(text.slice(0, 500));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,

--- a/workers/process-pr-events.ts
+++ b/workers/process-pr-events.ts
@@ -1,0 +1,41 @@
+/**
+ * Optional standalone worker — only needed if Next.js is not running (e.g. dedicated worker dyno).
+ * By default the embedded worker starts via instrumentation.ts (dev) or `after()` handles serverless.
+ *
+ * Run: npm run worker:pr-events
+ */
+import { startEmbeddedPrEventsWorker } from "@/lib/queue/pr-events-worker-runtime";
+import { closePrEventsDlq } from "@/lib/queue/pr-events-dlq";
+import { closePrEventsQueue } from "@/lib/queue/pr-events-queue";
+import { closeRedisConnection } from "@/lib/redis/client";
+
+async function main() {
+  process.env.ENABLE_PR_EVENTS_WORKER = "true";
+  const worker = await startEmbeddedPrEventsWorker();
+
+  if (!worker) {
+    console.error(
+      "[pr-events-worker] cannot start — set REDIS_URL and ENABLE_PR_EVENTS_WORKER=true",
+    );
+    process.exit(1);
+  }
+
+  console.log("[pr-events-worker] standalone mode (embedded worker)");
+
+  const shutdown = async () => {
+    console.log("[pr-events-worker] shutting down...");
+    await worker.close();
+    await closePrEventsQueue();
+    await closePrEventsDlq();
+    await closeRedisConnection();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+main().catch((error) => {
+  console.error("[pr-events-worker] fatal:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
# GitHub PR Webhook → Redis/BullMQ async pipeline

## Summary

Adds a secure GitHub webhook endpoint that ingests pull request lifecycle events, deduplicates deliveries, enqueues work to **BullMQ** (backed by **Redis/Upstash**), and persists enriched PR metadata to Supabase `pr_events`. Includes HMAC signature verification, a two-layer idempotency strategy, dead-letter queue handling, and automated in-app job processing (no separate worker process required for local dev).

---

## What we built

### API endpoint

- **`POST /api/github/webhook`** — receives GitHub webhook deliveries
  - Validates `X-Hub-Signature-256` using `GITHUB_WEBHOOK_SECRET`
  - Supports `application/json` and `application/x-www-form-urlencoded` (`payload=...`) bodies
  - Handles `ping` events (returns `200` immediately for webhook setup tests)
  - Maps PR events → internal job shape → Redis queue

### Event support

| GitHub event | Actions | Internal `event_type` |
|---|---|---|
| `pull_request` | `opened`, `reopened`, `ready_for_review` | `opened` |
| `pull_request` | `synchronize` | `synchronized` |
| `pull_request` | `edited`, `labeled`, `unlabeled`, `review_requested`, … | `edited` |
| `pull_request` | `closed` + merged | `merged` |
| `pull_request` | `closed` (not merged) | `closed` |
| `pull_request_review` | `submitted` | `reviewed` |

### Idempotency (Redis, 7-day TTL)

Two layers prevent duplicate processing:

| Layer | Key | Purpose |
|---|---|---|
| **Delivery** | `delivery:{X-GitHub-Delivery}` | Blocks GitHub redeliveries of the same HTTP request |
| **Semantic** | varies by event type | Blocks logically identical events |

**Semantic key rules:**

| `event_type` | Key format |
|---|---|
| `opened`, `synchronized`, `merged`, `closed` | `pr:{github_pt_id}:sha:{head_sha}:{event_type}` |
| `reviewed` | `pr:{github_pt_id}:review:{review_id}` |
| `edited` | `pr:{github_pt_id}:delivery:{delivery_id}` |

### Queue & processing

- **Main queue:** `pr-events` (BullMQ)
- **Dead-letter queue:** `pr-events-dlq` (jobs that exhaust retries)
- **Job payload** matches `pr_events` schema: repo, PR number, diff stats, path flags (`tests_touched`, `docs_touched`, `risky_paths_hit`), developer lookup via `profiles.github_username`, etc.
- **Enrichment** via GitHub REST API when `GITHUB_TOKEN` is set (additions, files, reviews, commits)

### Automated processing (inside Next.js)

No separate terminal required for local dev:

| Environment | How jobs are processed |
|---|---|
| **Local dev** (`npm run dev`) | Embedded BullMQ worker starts via `instrumentation.ts` |
| **Cloudflare / Vercel** | Post-response `after()` runs `fulfillPrEventJob` (retries + DLQ) |
| **Docker / `next start`** | Set `ENABLE_PR_EVENTS_WORKER=true` for embedded worker |

Optional standalone worker: `npm run worker:pr-events`

---

## Architecture

```mermaid
sequenceDiagram
    participant GH as GitHub
    participant WH as /api/github/webhook
    participant Redis as Redis / Upstash
    participant Q as BullMQ pr-events
    participant W as Embedded worker / after()
    participant SB as Supabase pr_events
    participant DLQ as pr-events-dlq

    GH->>WH: POST (signed payload)
    WH->>WH: Verify HMAC
    WH->>Redis: Claim idempotency keys
    WH->>Q: Enqueue job
    WH-->>GH: 200 OK (fast)
    W->>Q: Consume job
    W->>SB: Upsert pr_events
    alt success
        W->>Q: Remove job
    else retries exhausted
        W->>DLQ: Move failed job
    end
```

---

## Setup

### 1. Environment variables

Add to `.env.local` (see `.env.example`):

```env
REDIS_URL=rediss://...              # Upstash or redis://localhost:6379
GITHUB_WEBHOOK_SECRET=...           # Same secret as GitHub webhook settings  (Note: use command - openssl rand -hex 32  to get this token)
GITHUB_TOKEN=ghp_...                # Optional — enriches PR data from GitHub API
SUPABASE_SERVICE_ROLE_KEY=...       # Required to persist pr_events
NEXT_PUBLIC_SUPABASE_URL=...
```

### 2. Database

Run in Supabase SQL editor:

```bash
database/pr_events.sql
```

### 3. Redis

**Local (Docker):**

```bash
docker run -d -p 6379:6379 redis:7
# REDIS_URL=redis://localhost:6379
```

**Production:** Upstash Redis → copy `rediss://...` URL into `REDIS_URL`.

### 4. GitHub webhook

Repo → **Settings → Webhooks → Add webhook**

| Field | Value |
|---|---|
| Payload URL | `https://your-domain/api/github/webhook` |
| Content type | `application/json` (or `form` — both supported) |
| Secret | Same as `GITHUB_WEBHOOK_SECRET` |
| Events | **Pull requests**, **Pull request reviews** |

For local testing via ngrok:

```bash
ngrok http 3000
# Payload URL: https://<id>.ngrok-free.app/api/github/webhook
```

### 5. Start the app

```bash
npm run dev
```

You should see:

```text
[pr-events] embedded worker started
```

---

## Key files

| Path | Role |
|---|---|
| `app/api/github/webhook/route.ts` | Webhook HTTP handler |
| `lib/github/webhook-signature.ts` | HMAC-SHA256 verification |
| `lib/github/idempotency-key.ts` | Idempotency key strategy |
| `lib/github/idempotency-store.ts` | Redis idempotency claims |
| `lib/github/pr-event-support.ts` | Event/action mapping |
| `lib/github/build-pr-event-job.ts` | Payload → job + GitHub API enrichment |
| `lib/github/parse-webhook-body.ts` | JSON + form-urlencoded parsing |
| `lib/queue/pr-events-queue.ts` | BullMQ main queue |
| `lib/queue/pr-events-dlq.ts` | Dead-letter queue |
| `lib/queue/process-pr-event-job.ts` | Supabase upsert |
| `lib/queue/fulfill-pr-event-job.ts` | Inline processing + retries + DLQ |
| `lib/queue/pr-events-worker-runtime.ts` | Embedded worker singleton |
| `instrumentation.pr-events-worker.ts` | Auto-start worker on boot |
| `database/pr_events.sql` | Table schema |
| `scripts/test/test-github-webhook.mjs` | Signed manual test script |
| `lib/github/test/webhook.test.ts` | Unit tests |

---

## Testing

### Unit tests

```bash
npm run test -- lib/github/test/webhook.test.ts
```

Covers: HMAC verification, event mapping, idempotency keys, DLQ threshold, payload parsing.

### Manual signed requests

Script reads `GITHUB_WEBHOOK_SECRET` from `.env.local` and signs requests like GitHub:

```bash
# Ping (webhook health check)
npm run test:webhook -- ping

# Simulate pull_request opened
npm run test:webhook -- pr

# Via ngrok
npm run test:webhook -- pr https://YOUR-ID.ngrok-free.app
```

### Test results

**First delivery — job queued successfully (`200`):**

<img width="614" height="338" alt="image" src="https://github.com/user-attachments/assets/389916aa-9930-4993-8b6b-8bd164b23d63" />

```json
{
  "ok": true,
  "queued": true,
  "job_id": "d0d4b25d-dc26-4584-86ff-b963a1d853a6",
  "event_type": "opened",
  "pr_number": 1
}
```

**Second delivery — semantic idempotency blocks duplicate (`200`):**


<img width="640" height="316" alt="image" src="https://github.com/user-attachments/assets/360b66e2-1453-4fda-9e67-a2be26163d5d" />

```json
{
  "ok": true,
  "duplicate": true,
  "layer": "semantic",
  "idempotency_key": "pr:999001:sha:head000abc123:opened"
}
```

### GitHub webhook UI

1. Create webhook → GitHub sends `ping` → expect `{ "ok": true, "ping": true }`
2. Open/update a PR → Recent Deliveries → `200` with `queued: true`
3. Redeliver same event → `duplicate: true`
4. Verify row in Supabase `pr_events`

### Common responses

| Status | Response | Meaning |
|---|---|---|
| `200` | `{ "ping": true }` | Webhook configured correctly |
| `200` | `{ "queued": true }` | Event enqueued and processing scheduled |
| `200` | `{ "duplicate": true }` | Idempotency blocked replay |
| `401` | signature error | `GITHUB_WEBHOOK_SECRET` mismatch |
| `503` | Redis error | `REDIS_URL` missing or Redis down |

---

## Dependencies added

- `bullmq` — job queue
- `ioredis` — Redis client (Upstash-compatible with `rediss://`)

---

## Follow-ups (out of scope)

- [ ] DLQ replay admin API / dashboard
- [ ] Cloudflare Cron trigger to drain stuck jobs if `after()` fails
- [ ] Metrics/alerting on DLQ depth
- [ ] Handle `push` events (currently subscribed but skipped)

---

## Checklist for reviewers

- [ ] `REDIS_URL` + `GITHUB_WEBHOOK_SECRET` documented in `.env.example`
- [ ] `database/pr_events.sql` applied to Supabase
- [ ] `npm run test:webhook -- ping` returns `200`
- [ ] `npm run test:webhook -- pr` returns `queued: true` then `duplicate: true` on repeat
- [ ] GitHub webhook ping succeeds via ngrok/production URL
- [ ] `pr_events` row appears after processing
